### PR TITLE
include offset in output of "warcio index ..."

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,31 +16,31 @@ def test_index():
     files = ['example.warc.gz', 'example.warc', 'example.arc.gz', 'example.arc']
     files = [get_test_file(filename) for filename in files]
 
-    args = ['index', '-f', 'warc-type,warc-target-uri,warc-filename']
+    args = ['index', '-f', 'offset,warc-type,warc-target-uri,warc-filename']
     args.extend(files)
 
-    expected = """\
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "revisit", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "revisit", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
+    expected = b"""\
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 353, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 784, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"offset": 2012, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 2538, "warc-type": "revisit", "warc-target-uri": "http://example.com/"}
+{"offset": 3123, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 488, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 1197, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"offset": 2566, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 3370, "warc-type": "revisit", "warc-target-uri": "http://example.com/"}
+{"offset": 4316, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
+{"offset": 171, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
+{"offset": 151, "warc-type": "response", "warc-target-uri": "http://example.com/"}
 """
 
     with patch_stdout() as buff:
         res = main(args=args)
-        assert buff.getvalue().decode('utf-8') == expected
+        assert buff.getvalue() == expected
 
 
 def test_recompress():

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -19,28 +19,28 @@ def test_index():
     args = ['index', '-f', 'warc-type,warc-target-uri,warc-filename']
     args.extend(files)
 
-    expected = """\
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "revisit", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "revisit", "warc-target-uri": "http://example.com/"}
-{"warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
-{"warc-type": "response", "warc-target-uri": "http://example.com/"}
+    expected = b"""\
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 353, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 784, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"offset": 2012, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 2538, "warc-type": "revisit", "warc-target-uri": "http://example.com/"}
+{"offset": 3123, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 488, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"offset": 1197, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"offset": 2566, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 3370, "warc-type": "revisit", "warc-target-uri": "http://example.com/"}
+{"offset": 4316, "warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
+{"offset": 171, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"offset": 0, "warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
+{"offset": 151, "warc-type": "response", "warc-target-uri": "http://example.com/"}
 """
 
     with patch_stdout() as buff:
         res = main(args=args)
-        assert buff.getvalue().decode('utf-8') == expected
+        assert buff.getvalue() == expected
 
 
 def test_recompress():
@@ -55,12 +55,12 @@ def test_recompress():
         main(args=['recompress', test_file, temp.name])
 
         expected = """\
-{"warc-type": "warcinfo"}
-{"warc-type": "warcinfo"}
-{"warc-type": "response"}
-{"warc-type": "request"}
-{"warc-type": "revisit"}
-{"warc-type": "request"}
+{"offset": 0, "warc-type": "warcinfo"}
+{"offset": 353, "warc-type": "warcinfo"}
+{"offset": 784, "warc-type": "response"}
+{"offset": 2012, "warc-type": "request"}
+{"offset": 2583, "warc-type": "revisit"}
+{"offset": 2965, "warc-type": "request"}
 """
 
         with patch_stdout() as buff:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -19,28 +19,28 @@ def test_index():
     args = ['index', '-f', 'warc-type,warc-target-uri,warc-filename']
     args.extend(files)
 
-    expected = b"""\
-{"offset": 0, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"offset": 353, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"offset": 784, "warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"offset": 2012, "warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"offset": 2538, "warc-type": "revisit", "warc-target-uri": "http://example.com/"}
-{"offset": 3123, "warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"offset": 0, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"offset": 488, "warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
-{"offset": 1197, "warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"offset": 2566, "warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"offset": 3370, "warc-type": "revisit", "warc-target-uri": "http://example.com/"}
-{"offset": 4316, "warc-type": "request", "warc-target-uri": "http://example.com/"}
-{"offset": 0, "warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
-{"offset": 171, "warc-type": "response", "warc-target-uri": "http://example.com/"}
-{"offset": 0, "warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
-{"offset": 151, "warc-type": "response", "warc-target-uri": "http://example.com/"}
+    expected = """\
+{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"warc-type": "revisit", "warc-target-uri": "http://example.com/"}
+{"warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"warc-type": "warcinfo", "warc-filename": "temp-20170306040353.warc.gz"}
+{"warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"warc-type": "revisit", "warc-target-uri": "http://example.com/"}
+{"warc-type": "request", "warc-target-uri": "http://example.com/"}
+{"warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
+{"warc-type": "response", "warc-target-uri": "http://example.com/"}
+{"warc-type": "warcinfo", "warc-filename": "live-web-example.arc.gz"}
+{"warc-type": "response", "warc-target-uri": "http://example.com/"}
 """
 
     with patch_stdout() as buff:
         res = main(args=args)
-        assert buff.getvalue() == expected
+        assert buff.getvalue().decode('utf-8') == expected
 
 
 def test_recompress():
@@ -55,12 +55,12 @@ def test_recompress():
         main(args=['recompress', test_file, temp.name])
 
         expected = """\
-{"offset": 0, "warc-type": "warcinfo"}
-{"offset": 353, "warc-type": "warcinfo"}
-{"offset": 784, "warc-type": "response"}
-{"offset": 2012, "warc-type": "request"}
-{"offset": 2583, "warc-type": "revisit"}
-{"offset": 2965, "warc-type": "request"}
+{"warc-type": "warcinfo"}
+{"warc-type": "warcinfo"}
+{"warc-type": "response"}
+{"warc-type": "request"}
+{"warc-type": "revisit"}
+{"warc-type": "request"}
 """
 
         with patch_stdout() as buff:

--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -44,11 +44,10 @@ def indexer(cmd):
     with open_or_default(cmd.output, 'wt', sys.stdout) as out:
         for filename in cmd.inputs:
             with open(filename, 'rb') as fh:
-                for record in ArchiveIterator(fh,
-                                              no_record_parse=True,
-                                              arc2warc=True):
-
+                it = ArchiveIterator(fh, no_record_parse=True, arc2warc=True)
+                for record in it:
                     index = OrderedDict()
+                    index['offset'] = it.offset
                     for field in fields:
                         value = record.rec_headers.get_header(field)
                         if value:

--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -24,7 +24,7 @@ def main(args=None):
 
     index = subparsers.add_parser('index', help='WARC/ARC Indexer')
     index.add_argument('inputs', nargs='+')
-    index.add_argument('-f', '--fields', default='warc-type,warc-target-uri')
+    index.add_argument('-f', '--fields', default='offset,warc-type,warc-target-uri')
     index.add_argument('-o', '--output')
     index.set_defaults(func=indexer)
 
@@ -47,10 +47,12 @@ def indexer(cmd):
                 it = ArchiveIterator(fh, no_record_parse=True, arc2warc=True)
                 for record in it:
                     index = OrderedDict()
-                    index['offset'] = it.offset
                     for field in fields:
-                        value = record.rec_headers.get_header(field)
-                        if value:
+                        if field == 'offset':
+                            value = it.offset
+                        else:
+                            value = record.rec_headers.get_header(field)
+                        if value is not None:
                             index[field] = value
 
                     out.write(json.dumps(index) + '\n')


### PR DESCRIPTION
I realize that the other fields are configurable and that offset is different because it's not a warc record header. I think it's reasonable to always include the offset in the output though.

By the way strictly speaking ArchiveIterator isn't actually an iterator, you have to do iter(ArchiveIterator(...)) to get the iterator. It looks like it would be a pain to refactor though.