### PR TITLE
Merge for 1.3

### DIFF
--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,3 +1,15 @@
+1.3
+~~~
+- Support for reading "streaming" WARC records, with no ``Content-Length`` set. ``Content-Length`` and digests computed as expected when the record is written.
+
+- Additional tests for streaming WARC records, loading HTTP headers+payload from buffer, POST request record, arc2warc conversion.
+
+- ``recompress`` command now parses records fully and generates correct block and payload digests.
+
+- ``WARCWriter.writer.create_record_from_stream()`` removed, redundant with ``ArcWarcRecordLoader()``
+
+
+
 1.2
 ~~~
 - Support for special field ``offset`` to include WARC record offset when indexing (by @nlevitt, `#4 <https://github.com/webrecorder/warcio/issues/4>`_)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.2.1'
+__version__ = '1.3'
 
 
 class PyTest(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.2'
+__version__ = '1.2.1'
 
 
 class PyTest(TestCommand):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -69,6 +69,23 @@ def test_recompress():
             assert buff.getvalue().decode('utf-8') == expected
 
 
+def test_recompress_arc2warc():
+    with named_temp() as temp:
+        test_file = get_test_file('example.arc.gz')
+
+        # recompress!
+        main(args=['recompress', test_file, temp.name])
+
+        expected = """\
+{"warc-type": "warcinfo"}
+{"warc-type": "response", "warc-block-digest": "sha1:PEWDX5GTH66WU74WBPGFECIYBMPMP3FP", "warc-payload-digest": "sha1:B2LTWWPUOYAH7UIPQ7ZUPQ4VMBSVC36A"}
+"""
+
+        with patch_stdout() as buff:
+            main(args=['index', temp.name, '-f', 'warc-type,warc-block-digest,warc-payload-digest'])
+            assert buff.getvalue().decode('utf-8') == expected
+
+
 def test_recompress_bad_file():
     with named_temp() as temp:
         temp.write(b'abcdefg-not-a-warc\n')

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -249,7 +249,7 @@ def sample_request(writer):
     headers_list = [('User-Agent', 'foo'),
                     ('Host', 'example.com')]
 
-    http_headers = StatusAndHeaders('GET / HTTP/1.0', headers_list)
+    http_headers = StatusAndHeaders('GET / HTTP/1.0', headers_list, is_http_request=True)
 
     return writer.create_warc_record('http://example.com/', 'request',
                                      http_headers=http_headers)
@@ -363,7 +363,12 @@ class TestWarcWriter(object):
         assert content_buff in record_string
 
         rec_type = parsed_record.rec_type
+
         # verify http_headers
+
+        # match original
+        assert record.http_headers == parsed_record.http_headers
+
         if parsed_record.http_headers:
             assert rec_type in ('response', 'request', 'revisit')
         else:

--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -84,7 +84,7 @@ class Recompressor(object):
             writer = WARCWriter(filebuf=out, gzip=True)
 
             for record in ArchiveIterator(stream,
-                                          no_record_parse=True,
+                                          no_record_parse=False,
                                           arc2warc=True,
                                           verify_http=False):
 

--- a/warcio/recordloader.py
+++ b/warcio/recordloader.py
@@ -1,5 +1,3 @@
-#import collections
-
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.statusandheaders import StatusAndHeadersParser
 from warcio.statusandheaders import StatusAndHeadersParserException
@@ -8,7 +6,6 @@ from warcio.limitreader import LimitReader
 
 from warcio.bufferedreaders import BufferedReader, ChunkedDataReader
 
-#from warcio.wbexception import WbException
 from warcio.timeutils import timestamp_to_iso_date
 
 from six.moves import zip
@@ -134,7 +131,9 @@ class ArcWarcRecordLoader(object):
         http_headers = None
 
         # record has http headers
-        if (not no_record_parse and length > 0 and
+        # checking if length != 0 instead of length > 0
+        # since length == None is also accepted
+        if (not no_record_parse and length != 0 and
             (rec_type in self.HTTP_RECORDS
               and uri.startswith(self.HTTP_SCHEMES))):
 

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -15,8 +15,12 @@ class StatusAndHeaders(object):
     Status Line if first line of request/response
     Headers is a list of (name, value) tuples
     An optional protocol which appears on first line may be specified
+    If is_http_request is true, split http verb (instead of protocol) from start of statusline
     """
-    def __init__(self, statusline, headers, protocol='', total_len=0):
+    def __init__(self, statusline, headers, protocol='', total_len=0, is_http_request=False):
+        if is_http_request:
+            protocol, statusline = statusline.split(' ', 1)
+
         self.statusline = statusline
         self.headers = headers
         self.protocol = protocol


### PR DESCRIPTION
- Fully support loading streaming WARC records, where Content-Length is not known at read time. Content-Length and digests computed on write.

- Even more tests for streaming WARC records, loading from http buffer

- Fix `recompress` to ensure block + payload digests computed properly.

- Remove redundant `create_record_from_stream()`