### PR TITLE
be open-minded about byte and dict headers

### DIFF
--- a/test/test_statusandheaders.py
+++ b/test/test_statusandheaders.py
@@ -3,8 +3,8 @@
 >>> st1
 StatusAndHeaders(protocol = 'HTTP/1.0', statusline = '200 OK', headers = [('Content-Type', 'ABC'), ('Some', 'Value'), ('Multi-Line', 'Value1    Also This')])
 
-# add range
->>> StatusAndHeaders(statusline = '200 OK', headers=[('Content-Type', 'text/plain')]).add_range(10, 4, 100)
+# add range (and byte headers)
+>>> StatusAndHeaders(statusline = '200 OK', headers=[(b'Content-Type', b'text/plain')]).add_range(10, 4, 100)
 StatusAndHeaders(protocol = '', statusline = '206 Partial Content', headers = [('Content-Type', 'text/plain'), ('Content-Range', 'bytes 10-13/100'), ('Accept-Ranges', 'bytes')])
 
 # other protocol expected

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,30 +10,31 @@ except ImportError:
     pass
 
 
-def test_headers_to_str_headers():
-    result = [('foo', 'bar'), ('baz', 'barf')]
+class TestUtils(object):
+    def test_headers_to_str_headers(self):
+        result = [('foo', 'bar'), ('baz', 'barf')]
 
-    header_dict = {'foo': b'bar', b'baz': 'barf'}
-    ret = utils.headers_to_str_headers(header_dict)
-    assert Counter(ret) == Counter(result)
+        header_dict = {'foo': b'bar', b'baz': 'barf'}
+        ret = utils.headers_to_str_headers(header_dict)
+        assert Counter(ret) == Counter(result)
 
-    aiohttp_raw_headers = ((b'foo', b'bar'), (b'baz', b'barf'))
-    assert Counter(utils.headers_to_str_headers(aiohttp_raw_headers)) == Counter(result)
+        aiohttp_raw_headers = ((b'foo', b'bar'), (b'baz', b'barf'))
+        assert Counter(utils.headers_to_str_headers(aiohttp_raw_headers)) == Counter(result)
 
-@pytest.mark.skipif('multidict' not in sys.modules, reason='requires multidict be installed')
-def test_multidict_headers_to_str_headers():
-    result = [('foo', 'bar'), ('baz', 'barf')]
+    @pytest.mark.skipif('multidict' not in sys.modules, reason='requires multidict be installed')
+    def test_multidict_headers_to_str_headers(self):
+        result = [('foo', 'bar'), ('baz', 'barf')]
 
-    aiohttp_headers = MultiDict(foo='bar', baz=b'barf')
-    ret = utils.headers_to_str_headers(aiohttp_headers)
-    assert Counter(ret) == Counter(result)
+        aiohttp_headers = MultiDict(foo='bar', baz=b'barf')
+        ret = utils.headers_to_str_headers(aiohttp_headers)
+        assert Counter(ret) == Counter(result)
 
-    # This case-insensitive thingie titlecases the key
-    aiohttp_headers = CIMultiDict(foo='bar', baz=b'barf')
-    titlecase_result = [('Foo', 'bar'), ('Baz', 'barf')]
-    rtitlecase_result = titlecase_result
-    rtitlecase_result.reverse()
+        # This case-insensitive thingie titlecases the key
+        aiohttp_headers = CIMultiDict(foo='bar', baz=b'barf')
+        titlecase_result = [('Foo', 'bar'), ('Baz', 'barf')]
+        rtitlecase_result = titlecase_result
+        rtitlecase_result.reverse()
 
-    ret = utils.headers_to_str_headers(aiohttp_headers)
-    assert Counter(ret) == Counter(titlecase_result)
+        ret = utils.headers_to_str_headers(aiohttp_headers)
+        assert Counter(ret) == Counter(titlecase_result)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,7 +15,6 @@ def test_headers_to_str_headers():
 
     header_dict = {'foo': b'bar', b'baz': 'barf'}
     ret = utils.headers_to_str_headers(header_dict)
-    assert 0
     assert Counter(ret) == Counter(result)
 
     aiohttp_raw_headers = ((b'foo', b'bar'), (b'baz', b'barf'))

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,40 @@
+import sys
+import pytest
+from collections import Counter
+
+import warcio.utils as utils
+
+try:
+    from multidict import CIMultiDict, MultiDict
+except ImportError:
+    pass
+
+
+def test_headers_to_str_headers():
+    result = [('foo', 'bar'), ('baz', 'barf')]
+
+    header_dict = {'foo': b'bar', b'baz': 'barf'}
+    ret = utils.headers_to_str_headers(header_dict)
+    assert 0
+    assert Counter(ret) == Counter(result)
+
+    aiohttp_raw_headers = ((b'foo', b'bar'), (b'baz', b'barf'))
+    assert Counter(utils.headers_to_str_headers(aiohttp_raw_headers)) == Counter(result)
+
+@pytest.mark.skipif('multidict' not in sys.modules, reason='requires multidict be installed')
+def test_multidict_headers_to_str_headers():
+    result = [('foo', 'bar'), ('baz', 'barf')]
+
+    aiohttp_headers = MultiDict(foo='bar', baz=b'barf')
+    ret = utils.headers_to_str_headers(aiohttp_headers)
+    assert Counter(ret) == Counter(result)
+
+    # This case-insensitive thingie titlecases the key
+    aiohttp_headers = CIMultiDict(foo='bar', baz=b'barf')
+    titlecase_result = [('Foo', 'bar'), ('Baz', 'barf')]
+    rtitlecase_result = titlecase_result
+    rtitlecase_result.reverse()
+
+    ret = utils.headers_to_str_headers(aiohttp_headers)
+    assert Counter(ret) == Counter(titlecase_result)
+

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -32,8 +32,6 @@ class TestUtils(object):
         # This case-insensitive thingie titlecases the key
         aiohttp_headers = CIMultiDict(foo='bar', baz=b'barf')
         titlecase_result = [('Foo', 'bar'), ('Baz', 'barf')]
-        rtitlecase_result = titlecase_result
-        rtitlecase_result.reverse()
 
         ret = utils.headers_to_str_headers(aiohttp_headers)
         assert Counter(ret) == Counter(titlecase_result)

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -4,7 +4,7 @@ Representation and parsing of HTTP-style status + headers
 
 from six.moves import range
 from six import iteritems
-from warcio.utils import to_native_str
+from warcio.utils import to_native_str, headers_to_str_headers
 import uuid
 
 
@@ -22,7 +22,7 @@ class StatusAndHeaders(object):
             protocol, statusline = statusline.split(' ', 1)
 
         self.statusline = statusline
-        self.headers = headers
+        self.headers = headers_to_str_headers(headers)
         self.protocol = protocol
         self.total_len = total_len
         self.headers_buff = None

--- a/warcio/utils.py
+++ b/warcio/utils.py
@@ -1,6 +1,11 @@
 import six
 from contextlib import contextmanager
 
+try:
+    import collections.abc as collections_abc  # only works on python 3.3+
+except ImportError:
+    import collections as collections_abc
+
 BUFF_SIZE = 16384
 
 
@@ -24,3 +29,29 @@ def open_or_default(filename, mod, default_fh):  #pragma: no cover
         res.close()
     else:
         yield default_fh
+
+
+# #===========================================================================
+def headers_to_str_headers(headers):
+    '''
+    Converts dict or tuple-based headers of bytes or str to
+    tuple-based headers of str, which is the python norm (pep 3333)
+    '''
+    ret = []
+
+    if isinstance(headers, collections_abc.Mapping):
+        h = headers.items()
+    else:
+        h = headers
+
+    if six.PY2:
+        return h
+
+    for tup in h:
+        k, v = tup
+        if isinstance(k, six.binary_type):
+            k = k.decode('iso-8859-1')
+        if isinstance(v, six.binary_type):
+            v = v.decode('iso-8859-1')
+        ret.append((k, v))
+    return ret


### PR DESCRIPTION
This is as discussed in https://github.com/webrecorder/warcio/issues/16

I kind of punted on converting bytes/str/whatever for Python 2 because I don't really understand it. It still does dict -> list for python2.

If the user happens to have multidict installed (part of aiohttp), then the multidict tests will run. This is optional because warcio strives to avoid external dependencies. If there's a more-correct way to get that into the CI, I'd love to know it.