### PR TITLE
Decompression buffer fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 
 class PyTest(TestCommand):

--- a/test/test_bufferedreaders.py
+++ b/test/test_bufferedreaders.py
@@ -124,7 +124,16 @@ def test_brotli():
     brotli_buff = b'[\xff\xaf\x02\xc0"y\\\xfbZ\x8cB;\xf4%U\x19Z\x92\x99\xb15\xc8\x19\x9e\x9e\n{K\x90\xb9<\x98\xc8\t@\xf3\xe6\xd9M\xe4me\x1b\'\x87\x13_\xa6\xe90\x96{<\x15\xd8S\x1c'
 
     with closing(DecompressingBufferedReader(BytesIO(brotli_buff), decomp_type='br')) as x:
-        x.read() == b'The quick brown fox jumps over the lazy dog' * 4096
+        assert x.read() == b'The quick brown fox jumps over the lazy dog' * 4096
+
+
+@pytest.mark.skipif('br' not in DecompressingBufferedReader.DECOMPRESSORS, reason='brotli not available')
+def test_brotli_very_small_chunk():
+    brotli_buff = b'[\xff\xaf\x02\xc0"y\\\xfbZ\x8cB;\xf4%U\x19Z\x92\x99\xb15\xc8\x19\x9e\x9e\n{K\x90\xb9<\x98\xc8\t@\xf3\xe6\xd9M\xe4me\x1b\'\x87\x13_\xa6\xe90\x96{<\x15\xd8S\x1c'
+
+    # read 3 bytes at time, will need to read() multiple types before decompressor has enough to return something
+    with closing(DecompressingBufferedReader(BytesIO(brotli_buff), decomp_type='br', block_size=3)) as x:
+        assert x.read() == b'The quick brown fox jumps over the lazy dog' * 4096
 
 
 # Compression


### PR DESCRIPTION
Fix an issue where data is read, but not enough to decompress, resulting in an empty response.
Happens with brotli, but probably with gzip also.

If any raw data is read, there is a decompressor, and no data yet, keep reading!

Add test for reading small chunk at a time where this happens.

Also, don't run an empty buffer through decompressor at all