### PR TITLE
bufferedreader fix: continue decompressing if empty buffer (introduce…

### DIFF
--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,3 +1,8 @@
+1.3.4
+~~~~~
+- Continuous read for more data to decompress (introduced in 1.3.2 for brotli decomp) should only happen if no unused data remaining. Otherwise, likely at gzip member end.
+
+
 1.3.3
 ~~~~~
 - Set default read ``block_size`` to 16384, ensure ``block_size`` is never None (caused an issue in py2.7)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.3.3'
+__version__ = '1.3.4'
 
 
 class PyTest(TestCommand):

--- a/warcio/bufferedreaders.py
+++ b/warcio/bufferedreaders.py
@@ -110,7 +110,7 @@ class BufferedReader(object):
         # if raw data is not empty and decompressor set, but
         # decompressed buff is empty, keep reading --
         # decompressor likely needs more data to decompress
-        while data and self.decompressor and self.empty():
+        while data and self.decompressor and not self.decompressor.unused_data and self.empty():
             data = self.stream.read(block_size)
             self._process_read(data)
 


### PR DESCRIPTION
…d in 1.3.2 for brotli fix) should only happen if no unused data! Otherwise, at gzip member end. bump version to 1.3.4 for this fix