### PR TITLE
Fixed writer crashing if given a record with no content type

### DIFF
--- a/warcio/warcwriter.py
+++ b/warcio/warcwriter.py
@@ -249,8 +249,9 @@ class BaseWARCWriter(object):
         else:
             self.ensure_digest(record, block=True, payload=True)
 
-        # ensure proper content type
-        record.rec_headers.replace_header('Content-Type', record.content_type)
+        if(record.content_type != None):
+            # ensure proper content type
+            record.rec_headers.replace_header('Content-Type', record.content_type)
 
         if record.rec_type == 'revisit':
             http_headers_only = True


### PR DESCRIPTION
The WARC specification only recommends that a record have a content_type, it is not mandatory. If a record is encountered without a content_type then the writer shouldn't inject a content_type=None header and hence cause the writer to break later on.

This came about as I have a WARC file with a record in which has a content length of 0 and no content type. When I try to write that WARC back out to a different file, the writer would error due to it expecting the content_type field to be a string and getting None instead. 