### PR TITLE
Remove `data_files` from packaging, add Content-Length for range requests

### DIFF
--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,3 +1,10 @@
+1.5.1
+~~~~~
+
+- remove ``test/data`` from wheel build, as it breaks latest setuptools wheel installation
+- add ``Content-Length`` when adding ``Content-Range`` via ``StatusAndHeaders.add_range`` `#29 <https://github.com/webrecorder/warcio/issues/29>`_
+
+
 1.5.0
 ~~~~~
 - new extract cli command `#26 <https://github.com/webrecorder/warcio/issues/26>`_ (by @nlevitt)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 
 
 class PyTest(TestCommand):
@@ -27,7 +27,7 @@ setup(
     author='Ilya Kreymer',
     author_email='ikreymer@gmail.com',
     license='Apache 2.0',
-    packages=find_packages(),
+    packages=find_packages(exclude=['test']),
     url='https://github.com/webrecorder/warcio',
     description='Streaming WARC (and ARC) IO library',
     long_description=open('README.rst').read(),
@@ -37,9 +37,6 @@ setup(
     install_requires=[
         'six',
         ],
-    data_files=[
-        ('test/data', glob.glob('test/data/*')),
-    ],
     zip_safe=True,
     entry_points="""
         [console_scripts]

--- a/test/test_statusandheaders.py
+++ b/test/test_statusandheaders.py
@@ -5,7 +5,7 @@ StatusAndHeaders(protocol = 'HTTP/1.0', statusline = '200 OK', headers = [('Cont
 
 # add range (and byte headers)
 >>> StatusAndHeaders(statusline = '200 OK', headers=[(b'Content-Type', b'text/plain')]).add_range(10, 4, 100)
-StatusAndHeaders(protocol = '', statusline = '206 Partial Content', headers = [('Content-Type', 'text/plain'), ('Content-Range', 'bytes 10-13/100'), ('Accept-Ranges', 'bytes')])
+StatusAndHeaders(protocol = '', statusline = '206 Partial Content', headers = [('Content-Type', 'text/plain'), ('Content-Range', 'bytes 10-13/100'), ('Content-Length', '4'), ('Accept-Ranges', 'bytes')])
 
 # other protocol expected
 >>> StatusAndHeadersParser(['Other']).parse(StringIO(status_headers_1))  # doctest: +IGNORE_EXCEPTION_DETAIL

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -102,6 +102,7 @@ class StatusAndHeaders(object):
 
         self.statusline = '206 Partial Content'
         self.replace_header('Content-Range', content_range)
+        self.replace_header('Content-Length', str(part_len))
         self.replace_header('Accept-Ranges', 'bytes')
         return self
 


### PR DESCRIPTION
- Remove `test/data` from wheel distro, as it breaks latest setuptools wheel installation
- Add `Content-Length` when adding `Content-Range` via `StatusAndHeaders.add_range`