### PR TITLE
bufferedwriter close fix:

### DIFF
--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,3 +1,10 @@
+1.5.3
+~~~~~
+
+- Add ``close_stream`` option to BufferedReader, defaulting to True (as pre 1.5.2 behavior). `#34 <https://github.com/webrecorder/warcio/issues/34>`_
+- ArchiveIterator usage does not close the wrapped stream, only the decompressor (same as 1.5.2 behavior).
+
+
 1.5.2
 ~~~~~
 
@@ -6,6 +13,7 @@
 - ``WarcWriter.create_visit_record()`` accepts additional WARC headers dictionary
 - ``ArchiveIterator.close()`` added which calls ``decompressor.flush()`` to address possible issues in `#34 <https://github.com/webrecorder/warcio/issues/34>`_
 - Switch ``Warc-Record-ID`` uuid creation to ``uuid4()`` from ``uuid1()``
+
 
 1.5.1
 ~~~~~

--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,8 +1,7 @@
 1.5.3
 ~~~~~
 
-- Add ``close_stream`` option to BufferedReader, defaulting to True (as pre 1.5.2 behavior). `#34 <https://github.com/webrecorder/warcio/issues/34>`_
-- ArchiveIterator usage does not close the wrapped stream, only the decompressor (same as 1.5.2 behavior).
+- ArchiveIterator calls new ``close_decompressor()`` function in BufferedReader instead of close() to only close decompressor, not underlying stream.  `#35 <https://github.com/webrecorder/warcio/issues/35>`_
 
 
 1.5.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.5.2'
+__version__ = '1.5.3'
 
 
 class PyTest(TestCommand):

--- a/test/test_bufferedreaders.py
+++ b/test/test_bufferedreaders.py
@@ -96,7 +96,7 @@ Zero-Length chunk:
 
 from io import BytesIO
 from warcio.bufferedreaders import ChunkedDataReader, ChunkedDataException
-from warcio.bufferedreaders import DecompressingBufferedReader, BufferedReader
+from warcio.bufferedreaders import DecompressingBufferedReader
 from warcio.limitreader import LimitReader
 
 from contextlib import closing
@@ -151,27 +151,6 @@ def test_compress_mix():
     assert b == b'ABC'
     x.read_next_member()
     assert x.read() == b'123'
-
-
-def test_close_stream():
-    # don't close by default
-    b = BytesIO(b'abc')
-    with closing(BufferedReader(b, close_stream=False)) as fh:
-        assert fh.read() == b'abc'
-
-    # stream not close
-    b.seek(0)
-    assert b.read() == b'abc'
-
-    b.seek(0)
-
-    with closing(BufferedReader(b)) as fh:
-        assert fh.read() == b'abc'
-
-    # can't seek, already closed
-    with pytest.raises(ValueError):
-        b.seek(0)
-
 
 
 # Errors

--- a/test/test_bufferedreaders.py
+++ b/test/test_bufferedreaders.py
@@ -96,7 +96,7 @@ Zero-Length chunk:
 
 from io import BytesIO
 from warcio.bufferedreaders import ChunkedDataReader, ChunkedDataException
-from warcio.bufferedreaders import DecompressingBufferedReader
+from warcio.bufferedreaders import DecompressingBufferedReader, BufferedReader
 from warcio.limitreader import LimitReader
 
 from contextlib import closing
@@ -151,6 +151,27 @@ def test_compress_mix():
     assert b == b'ABC'
     x.read_next_member()
     assert x.read() == b'123'
+
+
+def test_close_stream():
+    # don't close by default
+    b = BytesIO(b'abc')
+    with closing(BufferedReader(b, close_stream=False)) as fh:
+        assert fh.read() == b'abc'
+
+    # stream not close
+    b.seek(0)
+    assert b.read() == b'abc'
+
+    b.seek(0)
+
+    with closing(BufferedReader(b)) as fh:
+        assert fh.read() == b'abc'
+
+    # can't seek, already closed
+    with pytest.raises(ValueError):
+        b.seek(0)
+
 
 
 # Errors

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -56,8 +56,7 @@ class ArchiveIterator(six.Iterator):
         self.ensure_http_headers = ensure_http_headers
 
         self.reader = DecompressingBufferedReader(self.fh,
-                                                  block_size=block_size,
-                                                  close_stream=False)
+                                                  block_size=block_size)
         self.offset = self.fh.tell()
         self.next_line = None
 
@@ -75,7 +74,7 @@ class ArchiveIterator(six.Iterator):
     def close(self):
         self.record = None
         if self.reader:
-            self.reader.close()
+            self.reader.close_decompressor()
             self.reader = None
 
     def _iterate_records(self):

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -56,7 +56,8 @@ class ArchiveIterator(six.Iterator):
         self.ensure_http_headers = ensure_http_headers
 
         self.reader = DecompressingBufferedReader(self.fh,
-                                                  block_size=block_size)
+                                                  block_size=block_size,
+                                                  close_stream=False)
         self.offset = self.fh.tell()
         self.next_line = None
 

--- a/warcio/bufferedreaders.py
+++ b/warcio/bufferedreaders.py
@@ -63,8 +63,10 @@ class BufferedReader(object):
 
     def __init__(self, stream, block_size=BUFF_SIZE,
                  decomp_type=None,
-                 starting_data=None):
+                 starting_data=None,
+                 close_stream=True):
         self.stream = stream
+        self._close_stream = close_stream
         self.block_size = block_size
 
         self._init_decomp(decomp_type)
@@ -222,6 +224,9 @@ class BufferedReader(object):
         return rem
 
     def close(self):
+        if self.stream and self._close_stream:
+            self.stream.close()
+
         self.stream = None
         self.buff = None
 

--- a/warcio/bufferedreaders.py
+++ b/warcio/bufferedreaders.py
@@ -63,10 +63,9 @@ class BufferedReader(object):
 
     def __init__(self, stream, block_size=BUFF_SIZE,
                  decomp_type=None,
-                 starting_data=None,
-                 close_stream=True):
+                 starting_data=None):
+
         self.stream = stream
-        self._close_stream = close_stream
         self.block_size = block_size
 
         self._init_decomp(decomp_type)
@@ -224,12 +223,15 @@ class BufferedReader(object):
         return rem
 
     def close(self):
-        if self.stream and self._close_stream:
+        if self.stream:
             self.stream.close()
+            self.stream = None
 
-        self.stream = None
         self.buff = None
 
+        self.close_decompressor()
+
+    def close_decompressor(self):
         if self.decompressor:
             self.decompressor.flush()
             self.decompressor = None


### PR DESCRIPTION
- add close_decompressor() to BufferedReader to fix #34 
- archiveiterator does not close underlying stream, as before, only the calls close_decompressor() Fixes #35
- bump version to 1.5.3, update changelist