### PR TITLE
New record HTTP http semantics

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = codecov
+branch = True
+omit =
+    */test/*
+    */tests/*
+

--- a/README.rst
+++ b/README.rst
@@ -121,14 +121,15 @@ Writing WARC Records
 
 Starting with 1.6, warcio introduces a way to 'record' HTTP/S traffic directly
 to a WARC file, by monkey-patching Python's ``http.client`` library.
-This approach works well with popular ``requests`` library often used to fetch
-HTTP/S content.
 
-### Create a WARC by Recording HTTP/S Traffic
+This approach works well with the popular ``requests`` library often used to fetch
+HTTP/S content. Note that ``requests`` must be imported after ``record_http`` module.
 
+Quickstart to Writing a WARC
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To fetch ``https://example.com/`` and save the response and request (response first)
-into a gzip compressed WARC file named ``example.warc.gz``, simply run:
+Fetching the url ``https://example.com/`` while saving the response and request
+into a gzip compressed WARC file named ``example.warc.gz`` can be done with the following four lines:
 
 .. code:: python
 
@@ -137,9 +138,9 @@ into a gzip compressed WARC file named ``example.warc.gz``, simply run:
 
     with record_http('example.warc.gz'):
         requests.get('https://example.com/')
-        requests.get('http://example.com/abc')
 
-The resulting WARC file contain 4 records, a response/request pair for each of the 2 urls.
+
+The WARC ``example.warc.gz`` will contain two records (the response is written first, then the request).
 
 
 Customizing WARC Writing

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ WARCIO: WARC (and ARC) Streaming Library
 
 
 Background
-~~~~~~~~~~
+----------
 
 This library provides a fast, standalone way to read and write `WARC
 Format <https://en.wikipedia.org/wiki/Web_ARChive>`__ commonly used in
@@ -119,9 +119,36 @@ records) that contain HTML:
 Writing WARC Records
 --------------------
 
+Starting with 1.6, warcio introduces a way to 'record' HTTP/S traffic directly
+to a WARC file, by monkey-patching Python's ``http.client`` library.
+This approach works well with popular ``requests`` library often used to fetch
+HTTP/S content.
+
+### Create a WARC by Recording HTTP/S Traffic
+
+
+To fetch ``https://example.com/`` and save the response and request (response first)
+into a gzip compressed WARC file named ``example.warc.gz``, simply run:
+
+.. code:: python
+
+    from warcio.record_http import record_http
+    import requests  # requests *must* be imported after record_http
+
+    with record_http('example.warc.gz'):
+        requests.get('https://example.com/')
+        requests.get('http://example.com/abc')
+
+The resulting WARC file contain 4 records, a response/request pair for each of the 2 urls.
+
+
+Customizing WARC Writing
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 The library provides a simple and extensible interface for writing WARC
 records conformant to WARC 1.0 ISO standard
 `(see draft) <http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf>`__
+Parts of WARC 1.1 spec are also being implemented.
 
 The library comes with a basic ``WARCWriter`` class for writing to a
 single WARC file and ``BufferWARCWriter`` for writing to an in-memory
@@ -129,6 +156,60 @@ buffer. The ``BaseWARCWriter`` can be extended to support more complex
 operations.
 
 (There is no support for writing legacy ARC files)
+
+For more flexibility, such as to use a custom ``WARCWriter`` class,
+the above example can be written as:
+
+.. code:: python
+
+    from warcio.record_http import record_http
+    from warcio import WARCWriter
+    import requests  # requests *must* be imported after record_http
+
+    with open('example.warc.gz', 'wb') as fh:
+        warc_writer = WARCWriter(fh)
+        with record_http(warc_writer):
+            requests.get('https://example.com/')
+            requests.get('http://example.com/abc')
+            
+
+Filtering Recording
+~~~~~~~~~~~~~~~~~~~
+
+When recording via HTTP, it is possible to provide a custom filter function, 
+which can be used to determine if a WARC request & response should actually be
+written or not.
+
+The filter function is called with the request and response record
+before they are written, and can be used to substitute a different record (for example, a revisit
+instead of a response), or to skip writing altogether by returning nothing, as shown below:
+
+.. code:: python
+
+    def filter_records(warc_writer, request, response):
+        # return None, None to indicate records should be skipped
+        if response.http_headers.get_statuscode() != 200:
+            return None, None
+            
+        # the response record can be replaced with a revisit record
+        elif check_for_dedup():
+            response = create_revisit_record(...)
+            
+        return request, response
+
+    with record_http('example.warc.gz', filter_records):
+         requests.get('https://example.com/')
+         
+Please refer to
+`test/test\_record_http.py <test/test_record_http.py>`__ for additional examples
+of recording ``requests`` traffic to WARC.
+
+Manual/Advanced WARC Writing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before 1.6, this was the primary method for fetching a url and then
+writing to a WARC. This process is a bit more verbose,
+but provides for full control of WARC creation and avoid monkey-patching.
 
 The following example loads ``http://example.com/``, creates a WARC
 response record, and writes it, gzip compressed, to ``example.warc.gz``
@@ -159,10 +240,12 @@ The block and payload digests are computed automatically.
 
         writer.write_record(record)
 
-The library also includes additional semantics for: - Creating
-``warcinfo`` and ``revisit`` records - Writing ``response`` and
-``request`` records together - Writing custom WARC records - Reading a
-full WARC record from a stream
+
+The library also includes additional semantics for:
+ - Creating ``warcinfo`` and ``revisit`` records
+ - Writing ``response`` and ``request`` records together
+ - Writing custom WARC records
+ - Reading a full WARC record from a stream
 
 Please refer to `warcwriter.py <warcio/warcwriter.py>`__ and
 `test/test\_writer.py <test/test_writer.py>`__ for additional examples.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.5.4'
+__version__ = '1.6.0'
 
 
 class PyTest(TestCommand):
@@ -47,6 +47,7 @@ setup(
     tests_require=[
         'pytest',
         'pytest-cov',
+        'httpbin==0.5.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/test/test_record_http.py
+++ b/test/test_record_http.py
@@ -1,0 +1,153 @@
+import threading
+from wsgiref.simple_server import make_server
+from io import BytesIO
+import time
+
+from warcio.record_http import record_http
+from warcio.warcwriter import BufferWARCWriter, WARCWriter
+import requests
+import json
+
+from warcio.archiveiterator import ArchiveIterator
+from warcio.utils import BUFF_SIZE
+
+
+# ==================================================================
+class TestRecordHttpBin(object):
+    @classmethod
+    def setup_class(cls):
+        from httpbin import app as httpbin_app
+
+        server = make_server('localhost', 0, httpbin_app)
+        addr, cls.port = server.socket.getsockname()
+
+        def run():
+            try:
+                server.serve_forever()
+            except  Exception as e:
+                print(e)
+
+        thread = threading.Thread(target=run)
+        thread.daemon = True
+        thread.start()
+        time.sleep(0.1)
+
+    def test_get_no_record(self):
+        url = 'http://localhost:{0}/get?foo=bar'.format(self.port)
+        res = requests.get(url, headers={'Host': 'httpbin.org'})
+
+        assert res.json()['args'] == {'foo': 'bar'}
+
+    def test_get(self):
+        warc_writer = BufferWARCWriter(gzip=False)
+
+        url = 'http://localhost:{0}/get?foo=bar'.format(self.port)
+        with record_http(warc_writer):
+            res = requests.get(url, headers={'Host': 'httpbin.org'})
+
+        assert res.json()['args'] == {'foo': 'bar'}
+
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == url
+        assert res.json() == json.loads(response.content_stream().read().decode('utf-8'))
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == url
+
+    def test_get_cache_to_file(self):
+        warc_writer = BufferWARCWriter(gzip=False)
+
+        url = 'http://localhost:{0}/bytes/{1}'.format(self.port, BUFF_SIZE * 2)
+        with record_http(warc_writer):
+            res = requests.get(url, headers={'Host': 'httpbin.org'})
+
+        assert len(res.content) == BUFF_SIZE * 2
+
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == url
+        assert res.content == response.content_stream().read()
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == url
+
+    def test_post_json(self):
+        warc_writer = BufferWARCWriter(gzip=False)
+
+        with record_http(warc_writer):
+            res = requests.post('http://localhost:{0}/post'.format(self.port),
+                                headers={'Host': 'httpbin.org'},
+                                json={'some': {'data': 'posted'}})
+
+        assert res.json()['json'] == {'some': {'data': 'posted'}}
+
+        # response
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+
+        assert res.json() == json.loads(response.content_stream().read().decode('utf-8'))
+
+        # request
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.http_headers['Content-Type'] == 'application/json'
+
+        data = request.content_stream().read().decode('utf-8')
+        assert data == '{"some": {"data": "posted"}}'
+
+    def test_post_stream(self):
+        warc_writer = BufferWARCWriter(gzip=False)
+
+        def nop_filter(request, response):
+            assert request
+            assert response
+            return request, response
+
+        postbuff = BytesIO(b'somedatatopost')
+
+        url = 'http://localhost:{0}/post'.format(self.port)
+
+        with record_http(warc_writer, nop_filter):
+            res = requests.post(url, data=postbuff)
+
+        # response
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == url
+
+        assert res.json() == json.loads(response.content_stream().read().decode('utf-8'))
+
+        # request
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == url
+
+        data = request.content_stream().read().decode('utf-8')
+        assert data == 'somedatatopost'
+
+
+    def test_skip_filter(self):
+        warc_writer = BufferWARCWriter(gzip=False)
+
+        def skip_filter(request, response):
+            assert request
+            assert response
+            return None, None
+
+        with record_http(warc_writer, skip_filter):
+            res = requests.get('http://localhost:{0}/get?foo=bar'.format(self.port),
+                               headers={'Host': 'httpbin.org'})
+
+        assert res.json()['args'] == {'foo': 'bar'}
+
+        # skipped, nothing written
+        assert warc_writer.get_contents() == b''
+
+

--- a/warcio/__init__.py
+++ b/warcio/__init__.py
@@ -1,4 +1,3 @@
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.archiveiterator import ArchiveIterator
 from warcio.warcwriter import WARCWriter
-from warcio.record_http import record_http

--- a/warcio/__init__.py
+++ b/warcio/__init__.py
@@ -1,3 +1,4 @@
 from warcio.statusandheaders import StatusAndHeaders
 from warcio.archiveiterator import ArchiveIterator
 from warcio.warcwriter import WARCWriter
+from warcio.record_http import record_http

--- a/warcio/record_http.py
+++ b/warcio/record_http.py
@@ -1,0 +1,177 @@
+import threading
+
+from io import BytesIO
+
+from six.moves import http_client as httplib
+
+from contextlib import contextmanager
+
+from array import array
+
+from warcio.utils import to_native_str, BUFF_SIZE
+
+from tempfile import SpooledTemporaryFile
+
+
+# ============================================================================
+orig_connection = httplib.HTTPConnection
+
+
+# ============================================================================
+class RecordingStream(object):
+    def __init__(self, fp, recorder):
+        self.fp = fp
+        self.recorder = recorder
+
+    # Used in PY2 Only
+    def read(self, amt=None):  #pragma: no cover
+        buff = self.fp.read(amt)
+        self.recorder.write_response(buff)
+        return buff
+
+    # Used in PY3 Only
+    def readinto(self, buff):  #pragma: no cover
+        res = self.fp.readinto(buff)
+        self.recorder.write_response(buff)
+        return res
+
+    def readline(self, maxlen=None):
+        line = self.fp.readline(maxlen)
+        self.recorder.write_response(line)
+        return line
+
+    def close(self):
+        self.recorder.done()
+        return self.fp.close()
+
+
+# ============================================================================
+class RecordingHTTPResponse(httplib.HTTPResponse):
+    def __init__(self, recorder, *args, **kwargs):
+        httplib.HTTPResponse.__init__(self, *args, **kwargs)
+        self.fp = RecordingStream(self.fp, recorder)
+
+
+# ============================================================================
+class RecordingHTTPConnection(httplib.HTTPConnection):
+    local = threading.local()
+
+    def __init__(self, *args, **kwargs):
+        orig_connection.__init__(self, *args, **kwargs)
+        if hasattr(self.local, 'recorder'):
+            self.recorder = self.local.recorder
+        else:
+            self.recorder = None
+
+        def make_recording_response(*args, **kwargs):
+            return RecordingHTTPResponse(self.recorder, *args, **kwargs)
+
+        if self.recorder:
+            self.response_class = make_recording_response
+
+    def send(self, data):
+        if not self.recorder:
+            orig_connection.send(self, data)
+            return
+
+        def send_request(buff):
+            if not self.recorder.url:
+                url = self._extract_url(buff)
+                self.recorder.url = url
+
+            orig_connection.send(self, buff)
+            self.recorder.write_request(buff)
+
+        # if sending request body as stream
+        if hasattr(data, 'read') and not isinstance(data, array):
+            while True:
+                buff = data.read(BUFF_SIZE)
+                if not buff:
+                    break
+
+                send_request(buff)
+        else:
+            send_request(data)
+
+    def request(self, *args, **kwargs):
+        if self.recorder:
+            self.recorder.start()
+        return orig_connection.request(self, *args, **kwargs)
+
+    def _extract_url(self, data):
+        buff = BytesIO(data)
+        line = to_native_str(buff.readline(), 'latin-1')
+
+        path = line.split(' ', 2)[1]
+
+        scheme = 'https' if self.default_port == 443 else 'http'
+        url = scheme + '://' + self.host
+        if self.port != self.default_port:
+            url += ':' + str(self.port)
+
+        url += path
+        return url
+
+
+# ============================================================================
+class RequestRecorder(object):
+    def __init__(self, writer, filter_func=None):
+        self.writer = writer
+        self.filter_func = filter_func
+        self.request_out = None
+        self.response_out = None
+        self.url = None
+        self.lock = threading.Lock()
+
+    def start(self):
+        self.request_out = self._create_buffer()
+        self.response_out = self._create_buffer()
+        self.url = None
+
+    def _create_buffer(self):
+        return SpooledTemporaryFile(BUFF_SIZE)
+
+    def write_request(self, buff):
+        self.request_out.write(buff)
+
+    def write_response(self, buff):
+        self.response_out.write(buff)
+
+    def _create_record(self, out, record_type):
+        length = out.tell()
+        out.seek(0)
+        return self.writer.create_warc_record(
+                uri=self.url,
+                record_type=record_type,
+                payload=out,
+                length=length)
+
+    def done(self):
+        try:
+            request = self._create_record(self.request_out, 'request')
+            response = self._create_record(self.response_out, 'response')
+
+            if self.filter_func:
+                request, response = self.filter_func(request, response)
+                if not request or not response:
+                    return
+
+            with self.lock:
+                self.writer.write_request_response_pair(request, response)
+        finally:
+            self.request_out.close()
+            self.response_out.close()
+
+
+# ============================================================================
+httplib.HTTPConnection = RecordingHTTPConnection
+# ============================================================================
+
+@contextmanager
+def record_http(warc_writer, filter_func=None):
+    recorder = RequestRecorder(warc_writer, filter_func)
+    RecordingHTTPConnection.local.recorder = recorder
+    yield
+    RecordingHTTPConnection.local.recorder = None
+
+

--- a/warcio/record_http.py
+++ b/warcio/record_http.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 
 from array import array
 
-from warcio.utils import to_native_str, BUFF_SIZE
+from warcio.utils import to_native_str, BUFF_SIZE, open
 from warcio.warcwriter import WARCWriter
 
 from tempfile import SpooledTemporaryFile
@@ -169,10 +169,10 @@ httplib.HTTPConnection = RecordingHTTPConnection
 # ============================================================================
 
 @contextmanager
-def record_http(warc_writer, filter_func=None, append=False):
+def record_http(warc_writer, filter_func=None, append=True):
     out = None
     if isinstance(warc_writer, str):
-        out = open(warc_writer, 'wb' if not append else 'ab')
+        out = open(warc_writer, 'ab' if append else 'xb')
         warc_writer = WARCWriter(out)
 
     try:

--- a/warcio/utils.py
+++ b/warcio/utils.py
@@ -1,4 +1,5 @@
 import six
+import os
 from contextlib import contextmanager
 
 try:
@@ -59,3 +60,21 @@ def headers_to_str_headers(headers):
             v = v.decode('iso-8859-1')
         ret.append((k, v))
     return ret
+
+
+#=============================================================================
+sys_open = open
+
+def open(filename, mode='r', **kwargs):  #pragma: no cover
+    """
+    open() which supports exclusive mode 'x' in python < 3.3
+    """
+    if six.PY3 or 'x' not in mode:
+        return sys_open(filename, mode, **kwargs)
+
+    fd = os.open(filename, os.O_EXCL | os.O_CREAT | os.O_WRONLY)
+    mode = mode.replace('x', 'w')
+    return os.fdopen(fd, mode, 0x664)
+
+
+


### PR DESCRIPTION
Adds support for much simplified semantics for creating a WARC file from http traffic by monkey-patching python http libraries to record the network traffic.
Monkey-patching actually done in `http.client` but designed to work well with the `requests` library.

Example usage:

```
with record_http('filename.warc.gz'):
    res = requests.get('http://example.com/')
```

More examples added to readme.

setup:  bumping version to 1.6.0 and adding better code coverage with branching

utils: adding `open()` method that provides support for exclusive open `x` option in python 2.7