### PR TITLE
Encode Non-ASCII HTTP Headers

### DIFF
--- a/test/test_statusandheaders.py
+++ b/test/test_statusandheaders.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 """
 >>> st1 = StatusAndHeadersParser(['HTTP/1.0']).parse(StringIO(status_headers_1))
 >>> st1
@@ -208,3 +211,20 @@ def test_validate_status():
     assert not StatusAndHeaders('Bad OK', []).validate_statusline('204 No Content')
 
 
+def test_non_ascii():
+    st = StatusAndHeaders('200 OK', [('Custom-Header', u'attachment; filename="Éxamplè"')])
+    res = st.to_ascii_bytes().decode('ascii')
+    assert res == "\
+200 OK\r\n\
+Custom-Header: attachment; filename*=UTF-8''%C3%89xampl%C3%A8\r\n\
+\r\n\
+"
+
+def test_non_ascii_2():
+    st = StatusAndHeaders('200 OK', [('Custom-Header', u'value; filename="Éxamplè"; param; other=испытание; another')])
+    res = st.to_ascii_bytes().decode('ascii')
+    assert res == "\
+200 OK\r\n\
+Custom-Header: value; filename*=UTF-8''%C3%89xampl%C3%A8; param; other*=UTF-8''%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5; another\r\n\
+\r\n\
+"

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -7,9 +7,13 @@ from six import iteritems
 from warcio.utils import to_native_str, headers_to_str_headers
 import uuid
 
+from six.moves.urllib.parse import quote
+import re
+
 
 #=================================================================
 class StatusAndHeaders(object):
+    ENCODE_HEADER_RX = re.compile(r'[=]["\']?([^;"]+)["\']?(?=[;]?)')
     """
     Representation of parsed http-style status line and headers
     Status Line if first line of request/response
@@ -153,6 +157,39 @@ headers = {2})".format(self.protocol, self.statusline, self.headers)
 
     def to_bytes(self, filter_func=None, encoding='utf-8'):
         return self.to_str(filter_func).encode(encoding) + b'\r\n'
+
+    def to_ascii_bytes(self, filter_func=None):
+        """ Attempt to encode the headers block as ascii
+            If encoding fails, call percent_encode_non_ascii_headers()
+            to encode any headers per RFCs
+        """
+        try:
+            string = self.to_str(filter_func)
+            string = string.encode('ascii')
+        except UnicodeEncodeError:
+            self.percent_encode_non_ascii_headers()
+            string = self.to_str(filter_func)
+            string = string.encode('ascii')
+
+        return string + b'\r\n'
+
+    def percent_encode_non_ascii_headers(self, encoding='UTF-8'):
+        """ Encode any headers that are not plain ascii
+            as UTF-8 as per:
+            https://tools.ietf.org/html/rfc8187#section-3.2.3
+            https://tools.ietf.org/html/rfc5987#section-3.2.2
+        """
+        def do_encode(m):
+            return "*={0}''".format(encoding) + quote(to_native_str(m.group(1)))
+
+        for index in range(len(self.headers) - 1, -1, -1):
+            curr_name, curr_value = self.headers[index]
+            try:
+                # test if header is ascii encodable, no action needed
+                curr_value.encode('ascii')
+            except:
+                new_value = self.ENCODE_HEADER_RX.sub(do_encode, curr_value)
+                self.headers[index] = (curr_name, new_value)
 
     # act like a (case-insensitive) dictionary of headers, much like other
     # python http headers apis including http.client.HTTPMessage

--- a/warcio/warcwriter.py
+++ b/warcio/warcwriter.py
@@ -222,7 +222,8 @@ class BaseWARCWriter(object):
         return warc_headers
 
     def _set_header_buff(self, record):
-        headers_buff = record.http_headers.to_bytes(self.header_filter, 'iso-8859-1')
+        # HTTP headers %-encoded as ascii (see to_ascii_bytes for more info)
+        headers_buff = record.http_headers.to_ascii_bytes(self.header_filter)
         record.http_headers.headers_buff = headers_buff
 
     def _write_warc_record(self, out, record):
@@ -273,8 +274,9 @@ class BaseWARCWriter(object):
 
         record.rec_headers.replace_header('Content-Length', str(record.length))
 
-        # write record headers
-        out.write(record.rec_headers.to_bytes())
+        # write record headers -- encoded as utf-8
+        # WARC headers can be utf-8 per spec
+        out.write(record.rec_headers.to_bytes(encoding='utf-8'))
 
         # write headers buffer, if any
         if record.http_headers:


### PR DESCRIPTION
To address the issue in #38, add %-encoding of HTTP headers that are non-ascii.
(While latin-1/iso-8859-1 headers are technically allowed, to be extra safe all non-ascii headers are encoded)

If a header such as:
```
Content-Disposition: attachment; filename="Lancement du Système d’Échange Local (SEL).pdf"
```

it will be converted to:
```
Content-Disposition: attachment; filename*=UTF-8''Lancement%20du%20Syst%C3%A8me%20d%E2%80%99%C3%89change%20Local%20%28SEL%29.pdf
```
before being written to WARC (per https://tools.ietf.org/html/rfc8187#section-3.2.3)

Adds `StatusAndHeaders.to_ascii_bytes()` to perform this conversion where necessary.
