### PR TITLE
capture_http improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,14 +147,17 @@ into a gzip compressed WARC file named ``example.warc.gz`` can be done with the 
 
 The WARC ``example.warc.gz`` will contain two records (the response is written first, then the request).
 
-To write to a default in-memory buffer (``BufferWARCWriter``) simply use ``capture_http() as writer`` semantics.
-Records from multiple requests will be concatenated as expected and the ``WARC-IP-Address`` header will also be set if available.
+To write to a default in-memory buffer (``BufferWARCWriter``), don't specify a filename, using ``with capture_http() as writer:``.
 
-The following `test case <test/test_capture_http.py>`__ demonstrates the resulting records created with ``capture_http``:
+Additional requests in the ``capture_http`` context and will be appended to the WARC as expected.
+
+The ``WARC-IP-Address`` header will also be added for each record if the IP address is available.
+
+The following example (similar to a `unit test from the test suite <test/test_capture_http.py>`__) demonstrates the resulting records created with ``capture_http``:
 
 .. code:: python
 
-    with capture_http(warc_version='1.1', gzip=True) as writer:
+    with capture_http() as writer:
         requests.get('http://example.com/')
         requests.get('https://google.com/')
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "pip install -U setuptools"
   - "pip install coverage pytest-cov codecov"
-  - "pip install 'colorma<0.4.0'"
+  - "pip install colorama==0.3.9"
   - "pip install pycparser==2.18"
   - "pip install brotlipy"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ environment:
 install:        
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "pip install -U setuptools"
-  - "pip install coverage pytest-cov codecov"
   - "pip install colorama==0.3.9"
+  - "pip install coverage pytest-cov codecov"
   - "pip install pycparser==2.18"
   - "pip install brotlipy"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "pip install -U setuptools"
   - "pip install coverage pytest-cov codecov"
+  - "pip install 'colorma<0.4.0'"
   - "pip install pycparser==2.18"
   - "pip install brotlipy"
 

--- a/test/test_capture_http.py
+++ b/test/test_capture_http.py
@@ -18,7 +18,7 @@ from warcio.warcwriter import BufferWARCWriter, WARCWriter
 
 
 # ==================================================================
-class TestRecordHttpBin(object):
+class TestCaptureHttpBin(object):
     @classmethod
     def setup_class(cls):
         from httpbin import app as httpbin_app
@@ -43,7 +43,7 @@ class TestRecordHttpBin(object):
     def teardown_class(cls):
         os.rmdir(cls.temp_dir)
 
-    def test_get_no_record(self):
+    def test_get_no_capture(self):
         url = 'http://localhost:{0}/get?foo=bar'.format(self.port)
         res = requests.get(url, headers={'Host': 'httpbin.org'})
 
@@ -161,7 +161,7 @@ class TestRecordHttpBin(object):
         # skipped, nothing written
         assert warc_writer.get_contents() == b''
 
-    def test_record_to_temp_file_append(self):
+    def test_capture_to_temp_file_append(self):
         full_path = os.path.join(self.temp_dir, 'example.warc.gz')
 
         url = 'http://localhost:{0}/get?foo=bar'.format(self.port)
@@ -195,7 +195,7 @@ class TestRecordHttpBin(object):
 
         os.remove(full_path)
 
-    def test_error_record_to_temp_file_no_append_no_overwrite(self):
+    def test_error_capture_to_temp_file_no_append_no_overwrite(self):
         full_path = os.path.join(self.temp_dir, 'example2.warc.gz')
 
         url = 'http://localhost:{0}/get?foo=bar'.format(self.port)


### PR DESCRIPTION
- Support for `WARC-IP-Address` header
- Support for `capture_http()` writing to default BufferWARCWriter
- Fixes default readline() param, missing flush()
- Fixes for appveyor build
- README update