### PR TITLE
statusandheaders ascii encoding: if regex format doesn't match, still…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 
 class PyTest(TestCommand):

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -76,14 +76,15 @@ WARC-Record-ID: <urn:uuid:12345678-feb0-11e6-8f83-68a86d1772ce>\r\n\
 WARC-Target-URI: http://example.com/\r\n\
 WARC-Date: 2000-01-01T00:00:00Z\r\n\
 WARC-Payload-Digest: sha1:B6QJ6BNJ3R4B23XXMRKZKHLPGJY2VE4O\r\n\
-WARC-Block-Digest: sha1:4OWI4LV5GWIWVTL2MPL7OHSLNNAQ3H4W\r\n\
+WARC-Block-Digest: sha1:KMUABC6URWIQ7QXCZDQ5FS6WIBBFRORR\r\n\
 Content-Type: application/http; msgtype=response\r\n\
-Content-Length: 207\r\n\
+Content-Length: 268\r\n\
 \r\n\
 HTTP/1.0 200 OK\r\n\
 Content-Type: text/plain; charset="UTF-8"\r\n\
 Content-Disposition: attachment; filename*=UTF-8\'\'%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5.txt\r\n\
 Custom-Header: somevalue\r\n\
+Unicode-Header: %F0%9F%93%81%20text%20%F0%9F%97%84%EF%B8%8F\r\n\
 \r\n\
 some\n\
 text\r\n\
@@ -343,10 +344,11 @@ some\ntext'.encode('utf-8')
 
 # ============================================================================
 @sample_record('response-unicode-header', RESPONSE_RECORD_UNICODE_HEADERS)
-def sample_response_from_buff(writer):
+def sample_response_unicode(writer):
     headers_list = [('Content-Type', 'text/plain; charset="UTF-8"'),
                     ('Content-Disposition', u'attachment; filename="испытание.txt"'),
-                    ('Custom-Header', 'somevalue')
+                    ('Custom-Header', 'somevalue'),
+                    ('Unicode-Header', '📁 text 🗄️'),
                    ]
 
     payload = b'some\ntext'

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -166,7 +166,7 @@ headers = {2})".format(self.protocol, self.statusline, self.headers)
         try:
             string = self.to_str(filter_func)
             string = string.encode('ascii')
-        except UnicodeEncodeError:
+        except (UnicodeEncodeError, UnicodeDecodeError):
             self.percent_encode_non_ascii_headers()
             string = self.to_str(filter_func)
             string = string.encode('ascii')
@@ -189,6 +189,9 @@ headers = {2})".format(self.protocol, self.statusline, self.headers)
                 curr_value.encode('ascii')
             except:
                 new_value = self.ENCODE_HEADER_RX.sub(do_encode, curr_value)
+                if new_value == curr_value:
+                    new_value = quote(curr_value)
+
                 self.headers[index] = (curr_name, new_value)
 
     # act like a (case-insensitive) dictionary of headers, much like other


### PR DESCRIPTION
… header to ensure ascii only header

tests: add tests for header containing arbitrary utf-8 content, ensure %-encoding
bump version to 1.6.2