### PR TITLE
optionally check block and payload digests

### DIFF
--- a/test/data/example-digest.warc
+++ b/test/data/example-digest.warc
@@ -1,0 +1,96 @@
+WARC/1.0
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:a9c5c23a-0221-11e7-8fe3-0242ac120007>
+WARC-Target-URI: http://example.com/
+WARC-Date: 2017-03-06T04:02:06Z
+WARC-Concurrent-To: <urn:uuid:a9c51e3e-0221-11e7-bf66-0242ac120005>
+WARC-Block-Digest: sha1:Z6W6WEQQQICP5WA7OWB2SS75WLK4K7Y3
+WARC-Payload-Digest: sha1:1112H3S6NNFQ2MSVX7XZKYAYSCX5QBYJ
+Content-Type: application/http; msgtype=request
+Content-Length: 493
+
+GET / HTTP/1.0
+Host: example.com
+Accept-Language: en-US,en;q=0.8,ru;q=0.6
+Referer: https://webrecorder.io/temp-MJFXHZ4S/temp/recording-session/record/http://example.com/
+Upgrade-Insecure-Requests: 1
+Connection: close
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Dnt: 1
+Accept-Encoding: gzip, deflate, sdch, br
+
+
+
+WARC/1.0
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:a9c5c23a-0221-11e7-8fe3-0242ac120007>
+WARC-Target-URI: http://example.com/
+WARC-Date: 2017-03-06T04:02:06Z
+WARC-Concurrent-To: <urn:uuid:a9c51e3e-0221-11e7-bf66-0242ac120005>
+WARC-Block-Digest: sha1:Z6W6WEQQQICP5WA7OWB2SS75WLK4K7Y3
+WARC-Payload-Digest: sha1:2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+Content-Type: application/http; msgtype=request
+Content-Length: 493
+
+GET / HTTP/1.0
+Host: example.com
+Accept-Language: en-US,en;q=0.8,ru;q=0.6
+Referer: https://webrecorder.io/temp-MJFXHZ4S/temp/recording-session/record/http://example.com/
+Upgrade-Insecure-Requests: 1
+Connection: close
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Dnt: 1
+Accept-Encoding: gzip, deflate, sdch, br
+
+
+
+WARC/1.0
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:a9c5c23a-0221-11e7-8fe3-0242ac120007>
+WARC-Target-URI: http://example.com/
+WARC-Date: 2017-03-06T04:02:06Z
+WARC-Concurrent-To: <urn:uuid:a9c51e3e-0221-11e7-bf66-0242ac120005>
+WARC-Block-Digest: sha1:Z6W6WEQQQICP5WA7OWB2SS75WLK4K7Y3
+WARC-Payload-Digest: sha1:2jmj7l5rSw0yVb/vlWAYkK/YBwk=
+Content-Type: application/http; msgtype=request
+Content-Length: 493
+
+GET / HTTP/1.0
+Host: example.com
+Accept-Language: en-US,en;q=0.8,ru;q=0.6
+Referer: https://webrecorder.io/temp-MJFXHZ4S/temp/recording-session/record/http://example.com/
+Upgrade-Insecure-Requests: 1
+Connection: close
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Dnt: 1
+Accept-Encoding: gzip, deflate, sdch, br
+
+
+
+WARC/1.0
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:a9c5c23a-0221-11e7-8fe3-0242ac120007>
+WARC-Target-URI: http://example.com/
+WARC-Date: 2017-03-06T04:02:06Z
+WARC-Concurrent-To: <urn:uuid:a9c51e3e-0221-11e7-bf66-0242ac120005>
+WARC-Block-Digest: sha1:z63rEhCCBP7YH3WDqUv9stXFfxs=
+WARC-Payload-Digest: sha1:2jmj7l5rSw0yVb_vlWAYkK_YBwk=
+Content-Type: application/http; msgtype=request
+Content-Length: 493
+
+GET / HTTP/1.0
+Host: example.com
+Accept-Language: en-US,en;q=0.8,ru;q=0.6
+Referer: https://webrecorder.io/temp-MJFXHZ4S/temp/recording-session/record/http://example.com/
+Upgrade-Insecure-Requests: 1
+Connection: close
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
+Dnt: 1
+Accept-Encoding: gzip, deflate, sdch, br
+
+
+

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,7 +5,7 @@ from . import get_test_file
 from contextlib import contextmanager
 from io import BytesIO
 
-from warcio.recordloader import ArchiveLoadFailed
+from warcio.exceptions import ArchiveLoadFailed
 
 import pytest
 import sys

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -1,6 +1,7 @@
 from warcio.bufferedreaders import DecompressingBufferedReader
 
-from warcio.recordloader import ArcWarcRecordLoader, ArchiveLoadFailed
+from warcio.exceptions import ArchiveLoadFailed
+from warcio.recordloader import ArcWarcRecordLoader
 
 from warcio.utils import BUFF_SIZE
 
@@ -41,7 +42,8 @@ class ArchiveIterator(six.Iterator):
 
     def __init__(self, fileobj, no_record_parse=False,
                  verify_http=False, arc2warc=False,
-                 ensure_http_headers=False, block_size=BUFF_SIZE):
+                 ensure_http_headers=False, block_size=BUFF_SIZE,
+                 check_digests=False):
 
         self.fh = fileobj
 
@@ -60,6 +62,7 @@ class ArchiveIterator(six.Iterator):
         self.offset = self.fh.tell()
         self.next_line = None
 
+        self.check_digests = check_digests
         self.err_count = 0
         self.record = None
 
@@ -236,7 +239,8 @@ class ArchiveIterator(six.Iterator):
                                                  next_line,
                                                  self.known_format,
                                                  self.no_record_parse,
-                                                 self.ensure_http_headers)
+                                                 self.ensure_http_headers,
+                                                 self.check_digests)
 
         self.member_info = None
 

--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser, RawTextHelpFormatter
 
-from warcio.recordloader import ArchiveLoadFailed
+from warcio.exceptions import ArchiveLoadFailed
 from warcio.archiveiterator import ArchiveIterator
 
 from warcio.warcwriter import WARCWriter

--- a/warcio/exceptions.py
+++ b/warcio/exceptions.py
@@ -1,0 +1,5 @@
+#=================================================================
+class ArchiveLoadFailed(Exception):
+    def __init__(self, reason):
+        self.msg = str(reason)
+        super(ArchiveLoadFailed, self).__init__(self.msg)

--- a/warcio/limitreader.py
+++ b/warcio/limitreader.py
@@ -1,3 +1,10 @@
+import base64
+import logging
+
+from warcio.exceptions import ArchiveLoadFailed
+from warcio.utils import to_native_str, Digester
+
+
 # ============================================================================
 class LimitReader(object):
     """
@@ -67,3 +74,144 @@ class LimitReader(object):
 
         return stream
 
+
+# ============================================================================
+class DigestVerifyingReader(object):
+    """
+    A reader which verifies the digest of the wrapped reader
+    """
+
+    def __init__(self, stream, length, check_digests=False, record_type=None,
+                 payload_digest=None, block_digest=None, segment_number=None):
+
+        self.stream = stream
+        self.limit = length
+        if check_digests:
+            self.exception = ArchiveLoadFailed
+        else:
+            self.exception = None
+
+        if record_type == 'revisit':
+            block_digest = None  # XXX my bug, or is example.warc wrong?
+            payload_digest = None  # no payload, so can't check it
+        if segment_number is not None:  #pragma: no cover
+            payload_digest = None
+
+        self.payload_digest = payload_digest
+        self.block_digest = block_digest
+
+        self.payload_digester = None
+        self.payload_digester_obj = None
+        self.block_digester = None
+
+        if block_digest:
+            try:
+                algo, _ = _parse_digest(block_digest)
+                self.block_digester = Digester(algo)
+            except ValueError:
+                self.problem('unknown hash algorithm name in block digest')
+                self.block_digester = None
+        if payload_digest:
+            # if these are going to raise, have them do it here
+            try:
+                algo, _ = _parse_digest(self.payload_digest)
+                self.payload_digester_obj = Digester(algo)
+            except ValueError:
+                self.problem('unknown hash algorithm name in payload digest')
+
+    def begin_payload(self):
+        self.payload_digester = self.payload_digester_obj
+        if self.limit == 0:
+            # payload is of length 0
+            if not _compare_digest_rfc_3548(self.payload_digester, self.payload_digest):
+                self.problem('payload digest failed: {}'.format(self.payload_digest))
+                self.payload_digester = None  # prevent double-fire
+
+    def _update(self, buff):
+        length = len(buff)
+        self.limit -= length
+
+        if self.payload_digester:
+            self.payload_digester.update(buff)
+        if self.block_digester:
+            self.block_digester.update(buff)
+
+        if self.limit == 0:
+            if not _compare_digest_rfc_3548(self.block_digester, self.block_digest):
+                self.problem('block digest failed: {}'.format(self.block_digest))
+            if not _compare_digest_rfc_3548(self.payload_digester, self.payload_digest):
+                self.problem('payload digest failed {}'.format(self.payload_digest))
+
+        return buff
+
+    def problem(self, reason):
+        if self.exception:
+            raise self.exception(reason)
+        else:
+            logging.warning(reason)
+
+    def read(self, length=None):
+        buff = self.stream.read(length)
+        return self._update(buff)
+
+    def readline(self, length=None):
+        buff = self.stream.readline(length)
+        return self._update(buff)
+
+
+def _compare_digest_rfc_3548(digester, digest):
+    '''
+    The WARC standard does not recommend a digest algorithm and appears to
+    allow any encoding from RFC3548. The Python base64 module supports
+    RFC3548 although the base64 alternate alphabet is not exactly a first
+    class citizen. Hopefully digest algos are named with the same names
+    used by OpenSSL.
+    '''
+    if not digester or not digest:
+        return True
+
+    digester_b32 = str(digester)
+
+    our_algo, our_value = _parse_digest(digester_b32)
+    warc_algo, warc_value = _parse_digest(digest)
+
+    warc_b32 = _to_b32(len(our_value), warc_value)
+
+    if our_value == warc_b32:
+        return True
+
+    return False
+
+
+def _to_b32(length, value):
+    '''
+    Convert value to base 32, given that it's supposed to have the same
+    length as the digest we're about to compare it to
+    '''
+    if len(value) == length:
+        return value  # casefold needed here? -- rfc recommends not allowing
+
+    if len(value) > length:
+        binary = base64.b16decode(value, casefold=True)  # we know Ilya does lowercase
+    else:
+        binary = _b64_wrapper(value)
+
+    return to_native_str(base64.b32encode(binary), encoding='ascii')
+
+
+base64_url_filename_safe_alt = b'-_'
+
+
+def _b64_wrapper(value):
+    if '-' in value or '_' in value:
+        return base64.b64decode(value, altchars=base64_url_filename_safe_alt)
+    else:
+        return base64.b64decode(value)
+
+
+def _parse_digest(digest):
+    algo, sep, value = digest.partition(':')
+    if sep == ':':
+        return algo, value
+    else:
+        raise ValueError('could not parse digest algorithm out of '+digest)

--- a/warcio/utils.py
+++ b/warcio/utils.py
@@ -1,6 +1,8 @@
 import six
 import os
 from contextlib import contextmanager
+import base64
+import hashlib
 
 try:
     import collections.abc as collections_abc  # only works on python 3.3+
@@ -60,6 +62,19 @@ def headers_to_str_headers(headers):
             v = v.decode('iso-8859-1')
         ret.append((k, v))
     return ret
+
+
+# ============================================================================
+class Digester(object):
+    def __init__(self, type_='sha1'):
+        self.type_ = type_
+        self.digester = hashlib.new(type_)
+
+    def update(self, buff):
+        self.digester.update(buff)
+
+    def __str__(self):
+        return self.type_ + ':' + to_native_str(base64.b32encode(self.digester.digest()))
 
 
 #=============================================================================


### PR DESCRIPTION
This pullreq incorporates previous review comments.

In order to know when the checksums should be checked, in this streaming environment, the DigestVerifyingReader does need to know the length of the block-and-payload. So I put that new class in limitreader.py and the length is a required arg.

check_digests=False is the default and it sends a logging.warning(). check_digests=True raises ArchiveLoadFailed.

"warcio recompress" doesn't print the new warning because it plays games with the underlying raw stream. As a followup I propose to write "warcio check" to fully read the stream and trigger the check_digests warning, plus check for other warc problems.