### PR TITLE
fix ensure_digest(block=True) call if no headers_buffer is available:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'
 
 
 class PyTest(TestCommand):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class PyTest(TestCommand):
         import pytest
         import sys
         import os
-        errcode = pytest.main(['--doctest-module', './warcio', '--cov', 'warcio', '-v', 'test/'])
+        errcode = pytest.main(['--doctest-modules', './warcio', '--cov', 'warcio', '-v', 'test/'])
         sys.exit(errcode)
 
 setup(

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -617,6 +617,9 @@ class TestWarcWriter(object):
 
         req = sample_request(builder)
 
+        # test explicitly calling ensure_digest with block digest enabled on a record
+        writer.ensure_digest(resp, block=True, payload=True)
+
         writer.write_request_response_pair(req, resp)
 
         stream = writer.get_stream()

--- a/warcio/warcwriter.py
+++ b/warcio/warcwriter.py
@@ -12,13 +12,12 @@ from warcio.statusandheaders import StatusAndHeadersParser
 class BaseWARCWriter(RecordBuilder):
 
     def __init__(self, gzip=True, *args, **kwargs):
-        super(BaseWARCWriter, self).__init__(warc_version=kwargs.get('warc_version'))
+        super(BaseWARCWriter, self).__init__(warc_version=kwargs.get('warc_version'),
+                                             header_filter=kwargs.get('header_filter'))
         self.gzip = gzip
         self.hostname = gethostname()
 
         self.parser = StatusAndHeadersParser([], verify=False)
-
-        self.header_filter = kwargs.get('header_filter')
 
     def write_request_response_pair(self, req, resp, params=None):
         url = resp.rec_headers.get_header('WARC-Target-URI')


### PR DESCRIPTION
Calling `ensure_digest(block=True)` on a record with no headers_buffer computed would cause an exception as RecordBuilder would access a `self` in a class method.
https://github.com/webrecorder/warcio/blob/3fffe1e85b2c447faf6cd81943f3196820151af2/warcio/recordbuilder.py#L187

Fixing so `header_filter` is now a member of RecordBuilder, and `ensure_digest` remains a regular method.
Added test for `ensure_digest(block=True, payload=True)`

Currently, Webrecorder is calling `ensure_digest(block=True, payload=True)` explicitly which might not be correct/necessary (https://github.com/webrecorder/webrecorder/blob/master/webrecorder/webrecorder/rec/webrecrecorder.py#L370) -- I think it does this for side-effect of computing the payload length for chunked payload and should be examined itself. Nevertheless, that should not cause warcio to break.

