### PR TITLE
Windows Fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.arc  -text
+*.warc -text
+*.gz   -text

--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,3 +1,11 @@
+1.7.1
+~~~~~
+
+- Windows fixes: Fix reading from stdin, ensure all WARCs/ARCs are treated as binary `#86 <https://github.com/webrecorder/warcio/pull/86>`_
+
+- Fix ``ensure_digest(block=True)`` breaking on an existing record, RecordBuilder supports ``header_filter`` `#85 <https://github.com/webrecorder/warcio/pull/85>`_
+
+
 1.7.0
 ~~~~~
 

--- a/test/test_archiveiterator.py
+++ b/test/test_archiveiterator.py
@@ -1,11 +1,12 @@
 from warcio.archiveiterator import ArchiveIterator, WARCIterator, ARCIterator
 from warcio.exceptions import ArchiveLoadFailed
-from warcio.bufferedreaders import DecompressingBufferedReader
+from warcio.bufferedreaders import DecompressingBufferedReader, BufferedReader
 
 from warcio.warcwriter import BufferWARCWriter
 
 import pytest
 from io import BytesIO
+import sys
 
 import os
 
@@ -110,12 +111,16 @@ class TestArchiveIterator(object):
         def raise_tell(x):
             raise Exception()
 
-        # on windows, this tell() exists but doesn't work correctly, so just override
+        # on windows, this tell() exists but doesn't work correctly, so just override (in py3)
         # this is designed to emulated stdin, which does not have a tell(), as expected
+        stdout = proc.stdout
         if os.name == 'nt' and hasattr(proc.stdout, 'tell'):
-            proc.stdout.tell = raise_tell
+            if sys.version_info < (3, 0):
+                stdout = BufferedReader(stdout)
+            else:
+                stdout.tell = raise_tell
 
-        with closing(ArchiveIterator(proc.stdout)) as a:
+        with closing(ArchiveIterator(stdout)) as a:
             for record in a:
                 assert record.rec_type == 'warcinfo'
                 assert a.get_record_offset() == 0
@@ -149,12 +154,17 @@ class TestArchiveIterator(object):
         def raise_tell(x):
             raise Exception()
 
-        # on windows, this tell() exists but doesn't work correctly, so just override
+        # on windows, this tell() exists but doesn't work correctly, so just override (in py3)
         # this is designed to emulated stdin, which does not have a tell(), as expected
+        stdout = proc.stdout
         if os.name == 'nt' and hasattr(proc.stdout, 'tell'):
-            proc.stdout.tell = raise_tell
+            #can't override tell() in py2
+            if sys.version_info < (3, 0):
+                stdout = BufferedReader(stdout)
+            else:
+                stdout.tell = raise_tell
 
-        with closing(ArchiveIterator(proc.stdout)) as a:
+        with closing(ArchiveIterator(stdout)) as a:
             for record in a:
                 assert record.rec_type == 'warcinfo'
                 assert a.get_record_offset() == 0

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -72,8 +72,8 @@ class ArchiveIterator(six.Iterator):
 
         try:
             self.offset = self.fh.tell()
-            # on windows stdin, tell() exists but always return
-            # detect and replace also
+            # on windows stdin, tell() exists but always returns 0
+            # detect if on windows and has stdin buffer (Fd 3?) and override
             assert(os.name != 'nt' and self.fh.name != 3)
         except:
             self.fh = UnseekableYetTellable(self.fh)

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -75,6 +75,8 @@ class ArchiveIterator(six.Iterator):
             self.offset = self.fh.tell()
             # on windows stdin, tell() exists but always returns 0
             # detect if on windows and has stdin buffer (Fd 3?) and override
+            print(self.fh)
+            print(self.fh.name)
             assert(os.name != 'nt' or self.fh.name != 3)
         except:
             self.fh = UnseekableYetTellable(self.fh)

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -5,6 +5,7 @@ from warcio.recordloader import ArcWarcRecordLoader
 
 from warcio.utils import BUFF_SIZE
 
+import os
 import sys
 import six
 

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -72,6 +72,9 @@ class ArchiveIterator(six.Iterator):
 
         try:
             self.offset = self.fh.tell()
+            # on windows stdin, tell() exists but always return
+            # detect and replace also
+            assert(os.name != 'nt' and self.fh.name != 3)
         except:
             self.fh = UnseekableYetTellable(self.fh)
             self.offset = self.fh.tell()

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -5,7 +5,6 @@ from warcio.recordloader import ArcWarcRecordLoader
 
 from warcio.utils import BUFF_SIZE
 
-import os
 import sys
 import six
 
@@ -73,9 +72,6 @@ class ArchiveIterator(six.Iterator):
 
         try:
             self.offset = self.fh.tell()
-            # on windows, tell() on certain streams (eg. stdin) always return 0
-            # to be safe, always override
-            assert(os.name != 'nt')
         except:
             self.fh = UnseekableYetTellable(self.fh)
             self.offset = self.fh.tell()

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -74,7 +74,7 @@ class ArchiveIterator(six.Iterator):
             self.offset = self.fh.tell()
             # on windows stdin, tell() exists but always returns 0
             # detect if on windows and has stdin buffer (Fd 3?) and override
-            assert(os.name != 'nt' and self.fh.name != 3)
+            assert(os.name != 'nt' or self.fh.name != 3)
         except:
             self.fh = UnseekableYetTellable(self.fh)
             self.offset = self.fh.tell()

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -73,11 +73,9 @@ class ArchiveIterator(six.Iterator):
 
         try:
             self.offset = self.fh.tell()
-            # on windows stdin, tell() exists but always returns 0
-            # detect if on windows and has stdin buffer (Fd 3?) and override
-            print(self.fh)
-            print(self.fh.name)
-            assert(os.name != 'nt' or self.fh.name != 3)
+            # on windows, tell() on certain streams (eg. stdin) always return 0
+            # to be safe, always override
+            assert(os.name != 'nt')
         except:
             self.fh = UnseekableYetTellable(self.fh)
             self.offset = self.fh.tell()


### PR DESCRIPTION
Fix all tests on windows:
- Ensure all WARC/ARC files are treated as binary
- Ensure reading from stdin works on windows, ignore existing tell() function and override anyway with UnseekableYetTellable reader
Update changelist for 1.7.1