### PR TITLE
Add feature to skip past corrupted records in a warc.gz file

### DIFF
--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -56,6 +56,7 @@ class ArchiveIterator(six.Iterator):
     def __init__(self, fileobj, no_record_parse=False,
                  verify_http=False, arc2warc=False,
                  ensure_http_headers=False, block_size=BUFF_SIZE,
+                 skip_bad_records=False,
                  check_digests=False):
 
         self.fh = fileobj
@@ -65,6 +66,8 @@ class ArchiveIterator(six.Iterator):
         self.known_format = None
 
         self.mixed_arc_warc = arc2warc
+
+        self.skip_bad_records = skip_bad_records
 
         self.member_info = None
         self.no_record_parse = no_record_parse
@@ -115,6 +118,12 @@ class ArchiveIterator(six.Iterator):
 
             except EOFError:
                 empty_record = True
+
+            except ArchiveLoadFailed as e:
+                if self.skip_bad_records:
+                    continue
+                else:
+                    raise e
 
             self.read_to_end()
 


### PR DESCRIPTION
Hi, I am using warcio to process some large warc.gz files. I noticed that some of these files have random corruptions part way through the file which prevents the `ArchiveIterator` from reading all the way through.

The change in this PR allows the `ArchiveIterator` to skip past random errors until it finds another valid WARC header. That way I can still read the contents of the file after the corruption. This behaviour is configurable with the `skip_bad_records` parameter, and the default behaviour is to reraise the exception.