### PR TITLE
ci: bound jinja2<3.0.0 for py27 fix, possible fix for #103

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - pip install brotlipy
   - python setup.py install
   - pip install coverage pytest-cov codecov
+  - pip install 'jinja2<3.0.0'
 
 script:
   - python setup.py test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - "pip install coverage pytest-cov codecov"
   - "pip install pycparser==2.18"
   - "pip install brotlipy"
+  - "pip install 'jinja2<3.0.0'"
 
 build_script:
   - "python setup.py install"


### PR DESCRIPTION
Fixes py2.7 test builds by using older version of jinja2 in tests