### PR TITLE
%-encoding fix: if header value does not contain a mutli-value separa…

### DIFF
--- a/test/test_statusandheaders.py
+++ b/test/test_statusandheaders.py
@@ -212,7 +212,7 @@ def test_validate_status():
 
 
 def test_non_ascii():
-    st = StatusAndHeaders('200 OK', [('Custom-Header', u'attachment; filename="Éxamplè"')])
+    st = StatusAndHeaders('200 OK', [('Custom-Header', 'attachment; filename="Éxamplè"')])
     res = st.to_ascii_bytes().decode('ascii')
     assert res == "\
 200 OK\r\n\
@@ -221,10 +221,19 @@ Custom-Header: attachment; filename*=UTF-8''%C3%89xampl%C3%A8\r\n\
 "
 
 def test_non_ascii_2():
-    st = StatusAndHeaders('200 OK', [('Custom-Header', u'value; filename="Éxamplè"; param; other=испытание; another')])
+    st = StatusAndHeaders('200 OK', [('Custom-Header', 'value; filename="Éxamplè"; param; other=испытание; another')])
     res = st.to_ascii_bytes().decode('ascii')
     assert res == "\
 200 OK\r\n\
 Custom-Header: value; filename*=UTF-8''%C3%89xampl%C3%A8; param; other*=UTF-8''%D0%B8%D1%81%D0%BF%D1%8B%D1%82%D0%B0%D0%BD%D0%B8%D0%B5; another\r\n\
+\r\n\
+"
+
+def test_non_ascii_3():
+    st = StatusAndHeaders('200 OK', [('Custom-Header', '“max-age=31536000″')])
+    res = st.to_ascii_bytes().decode('ascii')
+    assert res == "\
+200 OK\r\n\
+Custom-Header: %E2%80%9Cmax-age%3D31536000%E2%80%B3\r\n\
 \r\n\
 "

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -195,9 +195,15 @@ headers = {2})".format(self.protocol, self.statusline, self.headers)
                 # test if header is ascii encodable, no action needed
                 curr_value.encode('ascii')
             except:
-                new_value = self.ENCODE_HEADER_RX.sub(do_encode, curr_value)
-                if new_value == curr_value:
+                # if single value header, (eg. no ';'), %-encode entire header
+                if ';' not in curr_value:
                     new_value = quote(curr_value)
+
+                else:
+                # %-encode value in ; name="value"
+                    new_value = self.ENCODE_HEADER_RX.sub(do_encode, curr_value)
+                    if new_value == curr_value:
+                        new_value = quote(curr_value)
 
                 self.headers[index] = (curr_name, new_value)
 


### PR DESCRIPTION
…te by ';', %-encode entire header value,

fixes remaining issue in #95