### PR TITLE
Fix ordering of arguments in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,7 +258,7 @@ instead of a response), or to skip writing altogether by returning nothing, as s
 
 .. code:: python
 
-    def filter_records(warc_writer, request, response):
+    def filter_records(request, response, request_recorder):
         # return None, None to indicate records should be skipped
         if response.http_headers.get_statuscode() != '200':
             return None, None


### PR DESCRIPTION
The ordering of arguments in [implementation](https://github.com/webrecorder/warcio/blob/master/warcio/capture_http.py#L185): is `request`, `response` and `RequestRecorder` object, updated documentation accordingly. Also, changed third argument name as `warc_writer` was confusing.

closes #110