### PR TITLE
Fix capture_http() with http and https proxies

### DIFF
--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,9 +1,9 @@
 1.7.3
 ~~~~~
 
-- Fix documentation for capture_http filter_records `#110 <https://github.com/webrecorder/warcio/issues/110>`
+- Fix documentation for capture_http filter_records `#110 <https://github.com/webrecorder/warcio/pull/110>`_
 
-- Fix capture_http with http and https proxies `#113 <https://github.com/webrecorder/warcio/issues/113>`
+- Fix capture_http with http and https proxies `#113 <https://github.com/webrecorder/warcio/pull/113>`_
 
 
 1.7.2

--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,7 +1,9 @@
-N.N.N
+1.7.3
 ~~~~~
 
 - Fix documentation for capture_http filter_records `#110 <https://github.com/webrecorder/warcio/issues/110>`
+
+- Fix capture_http with http and https proxies `#113 <https://github.com/webrecorder/warcio/issues/113>`
 
 
 1.7.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 import glob
 
-__version__ = '1.7.2'
+__version__ = '1.7.3'
 
 
 class PyTest(TestCommand):
@@ -49,6 +49,7 @@ setup(
         'pytest-cov',
         'httpbin==0.5.0',
         'requests',
+        'wsgiprox',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test/test_capture_http.py
+++ b/test/test_capture_http.py
@@ -117,7 +117,7 @@ class TestCaptureHttpBin(object):
     def test_post_stream(self):
         warc_writer = BufferWARCWriter(gzip=False)
 
-        def nop_filter(request, response, warc_writer):
+        def nop_filter(request, response, recorder):
             assert request
             assert response
             return request, response
@@ -147,11 +147,10 @@ class TestCaptureHttpBin(object):
         data = request.content_stream().read().decode('utf-8')
         assert data == 'somedatatopost'
 
-
     def test_skip_filter(self):
         warc_writer = BufferWARCWriter(gzip=False)
 
-        def skip_filter(request, response, warc_writer):
+        def skip_filter(request, response, recorder):
             assert request
             assert response
             return None, None

--- a/test/test_capture_http_proxy.py
+++ b/test/test_capture_http_proxy.py
@@ -1,0 +1,115 @@
+from warcio.capture_http import capture_http
+
+import threading
+from wsgiref.simple_server import make_server
+import time
+
+import requests
+from warcio.archiveiterator import ArchiveIterator
+
+from pytest import raises
+
+
+# ==================================================================
+class TestCaptureHttpProxy():
+    @classmethod
+    def setup_class(cls):
+        def app(env, start_response):
+            result = ('Proxied: ' + env['PATH_INFO']).encode('utf-8')
+            headers = [('Content-Length', str(len(result)))]
+            start_response('200 OK', headers=headers)
+            return iter([result])
+
+        from wsgiprox.wsgiprox import WSGIProxMiddleware
+        wsgiprox = WSGIProxMiddleware(app, '/')
+
+        server = make_server('localhost', 0, wsgiprox)
+        addr, cls.port = server.socket.getsockname()
+
+        cls.proxies = {'https': 'localhost:' + str(cls.port),
+                       'http': 'localhost:' + str(cls.port)
+                      }
+
+        def run():
+            try:
+                server.serve_forever()
+            except  Exception as e:
+                print(e)
+
+        thread = threading.Thread(target=run)
+        thread.daemon = True
+        thread.start()
+        time.sleep(0.1)
+
+    def test_capture_http_proxy(self):
+        with capture_http() as warc_writer:
+            res = requests.get("http://example.com/test", proxies=self.proxies, verify=False)
+
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == "http://example.com/test"
+        assert response.content_stream().read().decode('utf-8') == 'Proxied: /http://example.com/test'
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == "http://example.com/test"
+
+        with raises(StopIteration):
+            assert next(ai)
+
+    def test_capture_https_proxy(self):
+        with capture_http() as warc_writer:
+            res = requests.get("https://example.com/test", proxies=self.proxies, verify=False)
+            res = requests.get("https://example.com/foo", proxies=self.proxies, verify=False)
+
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == "https://example.com/test"
+        assert response.content_stream().read().decode('utf-8') == 'Proxied: /https://example.com/test'
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == "https://example.com/test"
+
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == "https://example.com/foo"
+        assert response.content_stream().read().decode('utf-8') == 'Proxied: /https://example.com/foo'
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == "https://example.com/foo"
+
+        with raises(StopIteration):
+            assert next(ai)
+
+    def test_capture_https_proxy_same_session(self):
+        sesh = requests.session()
+        with capture_http() as warc_writer:
+            res = sesh.get("https://example.com/test", proxies=self.proxies, verify=False)
+            res = sesh.get("https://example.com/foo", proxies=self.proxies, verify=False)
+
+        ai = ArchiveIterator(warc_writer.get_stream())
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == "https://example.com/test"
+        assert response.content_stream().read().decode('utf-8') == 'Proxied: /https://example.com/test'
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == "https://example.com/test"
+
+        response = next(ai)
+        assert response.rec_type == 'response'
+        assert response.rec_headers['WARC-Target-URI'] == "https://example.com/foo"
+        assert response.content_stream().read().decode('utf-8') == 'Proxied: /https://example.com/foo'
+
+        request = next(ai)
+        assert request.rec_type == 'request'
+        assert request.rec_headers['WARC-Target-URI'] == "https://example.com/foo"
+
+        with raises(StopIteration):
+            assert next(ai)
+

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -50,6 +50,14 @@ class TestUtils(object):
             assert fh.readline().decode('utf-8') == 'NOTWARC/1.0\r\n'
 
         default_fh.seek(0)
+        with utils.open_or_default(b'-', 'rb', default_fh) as fh:
+            assert fh.readline().decode('utf-8') == 'NOTWARC/1.0\r\n'
+
+        default_fh.seek(0)
+        with utils.open_or_default(u'-', 'rb', default_fh) as fh:
+            assert fh.readline().decode('utf-8') == 'NOTWARC/1.0\r\n'
+
+        default_fh.seek(0)
         with utils.open_or_default(default_fh, 'rb', None) as fh:
             assert fh.readline().decode('utf-8') == 'NOTWARC/1.0\r\n'
 

--- a/warcio/capture_http.py
+++ b/warcio/capture_http.py
@@ -105,7 +105,8 @@ class RecordingHTTPConnection(httplib.HTTPConnection):
             self.recorder.write_request(buff)
 
         # if sending request body as stream
-        if hasattr(data, 'read') and not isinstance(data, array):
+        # (supported via httplib but seems unused via higher-level apis)
+        if hasattr(data, 'read') and not isinstance(data, array):  #pragma: no cover
             while True:
                 buff = data.read(BUFF_SIZE)
                 if not buff:
@@ -157,7 +158,7 @@ class RequestRecorder(object):
         return SpooledTemporaryFile(BUFF_SIZE)
 
     def set_remote_ip(self, remote_ip):
-        if remote_ip:
+        if remote_ip:  #pragma: no cover
             self.warc_headers['WARC-IP-Address'] = remote_ip
 
     def write_request(self, buff):

--- a/warcio/capture_http.py
+++ b/warcio/capture_http.py
@@ -210,6 +210,7 @@ class RequestRecorder(object):
             parts = path.split(":", 1)
             self.connect_host = parts[0]
             self.connect_port = int(parts[1]) if len(parts) > 1 else default_port
+            self.warc_headers['WARC-Proxy-Host'] = "https://{0}:{1}".format(host, port)
             return
 
         if self.connect_host:
@@ -219,6 +220,7 @@ class RequestRecorder(object):
             port = self.connect_port
 
         if path.startswith(('http:', 'https:')):
+            self.warc_headers['WARC-Proxy-Host'] = "http://{0}:{1}".format(host, port)
             self.url = path
             return
 

--- a/warcio/capture_http.py
+++ b/warcio/capture_http.py
@@ -99,9 +99,7 @@ class RecordingHTTPConnection(httplib.HTTPConnection):
             return
 
         def send_request(buff):
-            if not self.recorder.url:
-                url = self._extract_url(buff)
-                self.recorder.url = url
+            self.recorder.extract_url(buff, self.host, self.port, self.default_port)
 
             orig_connection.send(self, buff)
             self.recorder.write_request(buff)
@@ -117,24 +115,16 @@ class RecordingHTTPConnection(httplib.HTTPConnection):
         else:
             send_request(data)
 
+    def _tunnel(self, *args, **kwargs):
+        if self.recorder:
+            self.recorder.start_tunnel()
+
+        return orig_connection._tunnel(self, *args, **kwargs)
+
     def request(self, *args, **kwargs):
         if self.recorder:
             self.recorder.start()
         return orig_connection.request(self, *args, **kwargs)
-
-    def _extract_url(self, data):
-        buff = BytesIO(data)
-        line = to_native_str(buff.readline(), 'latin-1')
-
-        path = line.split(' ', 2)[1]
-
-        scheme = 'https' if self.default_port == 443 else 'http'
-        url = scheme + '://' + self.host
-        if self.port != self.default_port:
-            url += ':' + str(self.port)
-
-        url += path
-        return url
 
 
 # ============================================================================
@@ -145,13 +135,23 @@ class RequestRecorder(object):
         self.request_out = None
         self.response_out = None
         self.url = None
+        self.connect_host = self.connect_port = None
+        self.started_req = False
+        self.first_line_read = False
         self.lock = threading.Lock()
         self.warc_headers = {}
+
+    def start_tunnel(self):
+        self.connect_host = self.connect_port = None
+        self.started_req = False
+        self.first_line_read = False
 
     def start(self):
         self.request_out = self._create_buffer()
         self.response_out = self._create_buffer()
         self.url = None
+        self.started_req = True
+        self.first_line_read = False
 
     def _create_buffer(self):
         return SpooledTemporaryFile(BUFF_SIZE)
@@ -161,10 +161,12 @@ class RequestRecorder(object):
             self.warc_headers['WARC-IP-Address'] = remote_ip
 
     def write_request(self, buff):
-        self.request_out.write(buff)
+        if self.started_req:
+            self.request_out.write(buff)
 
     def write_response(self, buff):
-        self.response_out.write(buff)
+        if self.started_req:
+            self.response_out.write(buff)
 
     def _create_record(self, out, record_type):
         length = out.tell()
@@ -191,6 +193,41 @@ class RequestRecorder(object):
         finally:
             self.request_out.close()
             self.response_out.close()
+
+    def extract_url(self, data, host, port, default_port):
+        if self.first_line_read:
+            return
+
+        self.first_line_read = True
+        buff = BytesIO(data)
+        line = to_native_str(buff.readline(), 'latin-1')
+
+        parts = line.split(' ', 2)
+        verb = parts[0]
+        path = parts[1]
+
+        if verb == "CONNECT":
+            parts = path.split(":", 1)
+            self.connect_host = parts[0]
+            self.connect_port = int(parts[1]) if len(parts) > 1 else default_port
+            return
+
+        if self.connect_host:
+            host = self.connect_host
+
+        if self.connect_port:
+            port = self.connect_port
+
+        if path.startswith(('http:', 'https:')):
+            self.url = path
+            return
+
+        scheme = 'https' if default_port == 443 else 'http'
+        self.url = scheme + '://' + host
+        if port != default_port:
+            self.url += ':' + str(port)
+
+        self.url += path
 
 
 # ============================================================================


### PR DESCRIPTION
Ensure that `capture_http()` works when http/https proxies are set and the WARC is written with valid target uri, eg:

```
with capture_http('./test.warc'):
    requests.get('https://example.com/', verify=False, proxies={"https": "proxyhost:8080", "http: "proxyhost:8080"})
```

(Currently, https proxy doesn't work at all while http proxy ends up with wrong url).

The proxy used is also written to warc, eg. `WARC-Proxy-Host: https://proxyhost:8080`

Fixes issues raised in #112 