### PR TITLE
Failsafe if it fails to % - encode headers

### DIFF
--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -176,7 +176,7 @@ headers = {2})".format(self.protocol, self.statusline, self.headers)
         except (UnicodeEncodeError, UnicodeDecodeError):
             self.percent_encode_non_ascii_headers()
             string = self.to_str(filter_func)
-            string = string.encode('ascii')
+            string = string.encode('ascii', errors='replace')
 
         return string + b'\r\n'
 


### PR DESCRIPTION
If Warcio fails to % encode headers, at least when dealing with the exception replace the non-encodeable chracters with a stub. This is not an ideal fix, but at least WARCIO does not fail to decode and encode the same file and the most probable outcome is that a strange cookie gets a few chars replaced.

Temporary fix for issue: #128 
Until headers are treated as a byte stream when reencoding a file.