### PR TITLE
CLI Indexer: silently ignore brokenpipe signal

### DIFF
--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -65,7 +65,10 @@ def get_version():
 def indexer(cmd):
     inputs = cmd.inputs or ('-',)  # default to stdin
     _indexer = Indexer(cmd.fields, inputs, cmd.output)
-    _indexer.process_all()
+    try:
+        _indexer.process_all()
+    except BrokenPipeError:
+        pass
 
 
 # ============================================================================


### PR DESCRIPTION
This PR makes the cli indexer silently ignore the broken pipe signal (SIGPIPE) if the output is sent to a Unix pipe and not entirely consumed, e.g.

```
$> warcio index not-too-small.warc.gz | head
...
Traceback (most recent call last):
  File ".../bin/warcio", line 33, in <module>
    sys.exit(load_entry_point('warcio==1.7.4', 'console_scripts', 'warcio')())
  File ".../lib/python3.9/site-packages/warcio-1.7.4-py3.9.egg/warcio/cli.py", line 55, in main
  File ".../lib/python3.9/site-packages/warcio-1.7.4-py3.9.egg/warcio/cli.py", line 68, in indexer
  File ".../lib/python3.9/site-packages/warcio-1.7.4-py3.9.egg/warcio/indexer.py", line 33, in process_all
  File ".../lib/python3.9/site-packages/warcio-1.7.4-py3.9.egg/warcio/indexer.py", line 41, in process_one
  File ".../lib/python3.9/site-packages/warcio-1.7.4-py3.9.egg/warcio/indexer.py", line 53, in process_index_entry
  File ".../lib/python3.9/site-packages/warcio-1.7.4-py3.9.egg/warcio/indexer.py", line 87, in _write_line
BrokenPipeError: [Errno 32] Broken pipe

# alternatively
$> warcio index -o >(head) not-too-small.warc.gz
```
