### PR TITLE
Add support for the 1995 NCSA 1.5.1 webserver

### DIFF
--- a/warcio/recordloader.py
+++ b/warcio/recordloader.py
@@ -48,7 +48,7 @@ class ArcWarcRecord(object):
 class ArcWarcRecordLoader(object):
     WARC_TYPES = ['WARC/1.1', 'WARC/1.0', 'WARC/0.17', 'WARC/0.18']
 
-    HTTP_TYPES = ['HTTP/1.0', 'HTTP/1.1']
+    HTTP_TYPES = ['HTTP/1.0', 'HTTP/1.1', 'HTTP']
 
     HTTP_VERBS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'TRACE',
                   'OPTIONS', 'CONNECT', 'PATCH']


### PR DESCRIPTION
I'm not sure this is the best solution here but it does allow archives of sites archived from the  NCSA 1.5.1 webserver to replay.