### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -19,7 +19,7 @@
 1.7.2
 ~~~~~
 
-- Ensure 1.1 revisit profile used with WARC/1.1 revists `#96 <https://github.com/webrecorder/warcio/pull/96>`_
+- Ensure 1.1 revisit profile used with WARC/1.1 revisits `#96 <https://github.com/webrecorder/warcio/pull/96>`_
 
 - Include record offsets in ``warcio check`` output `#98 <https://github.com/webrecorder/warcio/pull/98>`_
 

--- a/test/test_bufferedreaders.py
+++ b/test/test_bufferedreaders.py
@@ -61,7 +61,7 @@ Non-chunked, compressed data, specify decomp_type
 >>> print_str(ChunkedDataReader(BytesIO(compress('ABCDEF')), decomp_type='gzip').read())
 'ABCDEF'
 
-Non-chunked, compressed data, specifiy compression seperately
+Non-chunked, compressed data, specify compression separately
 >>> c = ChunkedDataReader(BytesIO(compress('ABCDEF'))); c.set_decomp('gzip'); print_str(c.read())
 'ABCDEF'
 

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -161,7 +161,7 @@ class ArchiveIterator(six.Iterator):
         - For uncompressed, they are between records and so are NOT part of
           the record length
 
-          count empty_size so that it can be substracted from
+          count empty_size so that it can be subtracted from
           the record length for uncompressed
 
           if first line read is not blank, likely error in WARC/ARC,

--- a/warcio/recordloader.py
+++ b/warcio/recordloader.py
@@ -80,7 +80,7 @@ class ArcWarcRecordLoader(object):
         and a stream limited to the remainder of the record.
 
         Pass statusline and known_format to detect_type_loader_headers()
-        to faciliate parsing.
+        to facilitate parsing.
         """
         (the_format, rec_headers) = (self.
                                      _detect_type_load_headers(stream,


### PR DESCRIPTION
https://pypi.org/project/codespell
```
./CHANGELIST.rst:22: revists ==> revisits
./test/test_bufferedreaders.py:64: specifiy ==> specify
./test/test_bufferedreaders.py:64: seperately ==> separately
./warcio/recordloader.py:83: faciliate ==> facilitate
./warcio/archiveiterator.py:164: substracted ==> subtracted
```