### PR TITLE
Add dependency for setuptools, which is required by cli get_version command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         ],
     install_requires=[
         'six',
+        'setuptools',
         ],
     zip_safe=True,
     entry_points="""


### PR DESCRIPTION
When I install warcio with [pipx](https://pipx.pypa.io/) `pkg_resources` from setuptools is missing in the venv.

```
$ pipx install warcio                                                      
  installed package warcio 1.7.4, installed using Python 3.12.4
  These apps are now globally available
    - warcio
done! ✨ 🌟 ✨

$ warcio --version                                                         
Traceback (most recent call last):
  File "…/.local/bin/warcio", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "…/.local/share/pipx/venvs/warcio/lib64/python3.12/site-packages/warcio/cli.py", line 16, in main
    parser.add_argument('-V', '--version', action='version', version=get_version())
                                                                     ^^^^^^^^^^^^^
  File "…/.local/share/pipx/venvs/warcio/lib64/python3.12/site-packages/warcio/cli.py", line 60, in get_version
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'

$ pipx uninstall warcio
uninstalled warcio! ✨ 🌟 ✨

$ pipx install git+https://github.com/white-gecko/warcio.git@feature/fixSetup
  installed package warcio 1.7.4, installed using Python 3.12.4
  These apps are now globally available
    - warcio
done! ✨ 🌟 ✨

$ warcio --version                                                           
warcio 1.7.4
```