### PR TITLE
Run pytest directly. setup.py test was removed in setuptools 72.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,9 @@ jobs:
         run: python setup.py install
 
       - name: Run tests
-        run: python setup.py test
+        run: |
+          pip install -e ".[testing]"
+          python -m pytest
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -v --cov warcio --doctest-modules
+testpaths =
+    warcio
+    test

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,6 @@ class PyTest(TestCommand):
         # should work with setuptools <18, 18 18.5
         self.test_suite = ' '
 
-    def run_tests(self):
-        import pytest
-        import sys
-        import os
-        errcode = pytest.main(['--doctest-modules', './warcio', '--cov', 'warcio', '-v', 'test/'])
-        sys.exit(errcode)
-
 setup(
     name='warcio',
     version=__version__,
@@ -44,15 +37,17 @@ setup(
     """,
     cmdclass={'test': PyTest},
     test_suite='',
-    tests_require=[
-        'urllib3==1.25.11',
-        'pytest',
-        'pytest-cov',
-        'httpbin>=0.10.2',
-        'requests',
-        'wsgiprox',
-        'hookdns',
-    ],
+    extras_require={
+        'testing': [
+            'urllib3==1.25.11',
+            'pytest',
+            'pytest-cov',
+            'httpbin>=0.10.2',
+            'requests',
+            'wsgiprox',
+            'hookdns',
+        ]
+    },
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',


### PR DESCRIPTION
Run pytest directly. setup.py test was removed in setuptools 72.
https://setuptools.pypa.io/en/latest/history.html#v72-0-0

Derived from #169 . Lets split it into portions.