### PR TITLE
Add very simple test for version argument and use importlib feature instead of deprecated pkg_resources for version

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,6 +12,12 @@ import sys
 import tempfile
 import os
 
+def test_version(capsys):
+    with pytest.raises(SystemExit):
+        main(args=['--version'])
+    out, err = capsys.readouterr()
+    print(out, err)
+    assert len(out) > 0
 
 def test_index(capsys):
     files = ['example.warc.gz', 'example.warc', 'example.arc.gz', 'example.arc']

--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -5,6 +5,7 @@ from warcio.checker import Checker
 from warcio.extractor import Extractor
 from warcio.recompressor import Recompressor
 
+from importlib.metadata import version
 import sys
 
 
@@ -57,8 +58,7 @@ def main(args=None):
 
 # ============================================================================
 def get_version():
-    import pkg_resources
-    return '%(prog)s ' + pkg_resources.get_distribution('warcio').version
+    return '%(prog)s ' + version('warcio')
 
 
 # ============================================================================

--- a/warcio/cli.py
+++ b/warcio/cli.py
@@ -5,7 +5,13 @@ from warcio.checker import Checker
 from warcio.extractor import Extractor
 from warcio.recompressor import Recompressor
 
-from importlib.metadata import version
+
+try:
+    from importlib.metadata import version
+except ImportError:
+    import pkg_resources
+    def version(package):
+        return pkg_resources.get_distribution(package).version
 import sys
 
 


### PR DESCRIPTION
Add very simple test for version argument and use importlib feature instead of deprecated pkg_resources for version.

Drop python 3.7 support (importlib.metadata) was introduced with python 3.8

Derived from https://github.com/webrecorder/warcio/pull/169 . Lets split it into portions.