### PR TITLE
Test python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,16 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Install setuptools on python 3.12
+        if: ${{ matrix.python-version == '3.12' }}
+        run: |
+          pip install setuptools
 
       - name: Install warcio
         run: python setup.py install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: checkout

--- a/CHANGELIST.rst
+++ b/CHANGELIST.rst
@@ -1,3 +1,9 @@
+Unreleased
+~~~~~~~~~~
+
+- Add support for Python 3.12 by adjusting `urllib3` dependency to `>=1.26.4,<1.26.16`
+
+
 1.7.4
 ~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     test_suite='',
     extras_require={
         'testing': [
-            'urllib3==1.25.11',
+            'urllib3>=1.26.5,<1.26.16',
             'pytest',
             'pytest-cov',
             'httpbin>=0.10.2',


### PR DESCRIPTION
Requires: #172

Add python 3.12 to the build matrix.
Install `setuptools` in test environment for python 3.12 (cf. #168).