### PR TITLE
Stream Recompressor

### DIFF
--- a/test/test_recompressor.py
+++ b/test/test_recompressor.py
@@ -1,5 +1,5 @@
 from . import get_test_file
-from warcio.recompressor import Recompressor
+from warcio.recompressor import Recompressor, StreamRecompressor
 
 import gzip
 import pytest
@@ -53,3 +53,39 @@ def test_recompress_non_chunked_decompressed_stream(tmp_path):
     with gzip.open(test_file, "rb") as input, open(tmp_file, "wb") as output:
         count = recompressor._load_and_write_stream(input, output)
     assert count == 6
+
+def test_stream_recompress_non_chunked_decompressed_stream(tmp_path):
+    """Uncompress a badly chunked stream with gzip befor feeding it to the StreamRecompressor's recompress method as stream."""
+    test_file = get_test_file('example-bad-non-chunked.warc.gz')
+    tmp_file = tmp_path / "output.warc.gz"
+    with gzip.open(test_file, "rb") as input, open(tmp_file, "wb") as output:
+        recompressor = StreamRecompressor(input, output, verbose=True)
+        count = recompressor.recompress()
+    assert count == 6
+
+def test_stream_recompress_chunked_compressed_stream(tmp_path):
+    """Open a chunked compressed stream, feeding it to the StreamRecompressor's recompress method as stream."""
+    test_file = get_test_file('example-resource.warc.gz')
+    tmp_file = tmp_path / "output.warc.gz"
+    with open(test_file, "rb") as input, open(tmp_file, "wb") as output:
+        recompressor = StreamRecompressor(input, output, verbose=True)
+        count = recompressor.recompress()
+    assert count == 3
+
+def test_stream_decompress_recompress_non_chunked_compressed_stream(tmp_path):
+    """Open a badly chunked stream and feed it to the StreamRecompressor's decompress_recompress method as stream."""
+    test_file = get_test_file('example-bad-non-chunked.warc.gz')
+    tmp_file = tmp_path / "output.warc.gz"
+    with open(test_file, "rb") as input, open(tmp_file, "wb") as output:
+        recompressor = StreamRecompressor(input, output, verbose=True)
+        count = recompressor.decompress_recompress()
+    assert count == 6
+
+def test_stream_decompress_recompress_chunked_stream(tmp_path):
+    """Open a chunked compressed stream and feed it to the StreamRecompressor's decompress_recompress method as stream."""
+    test_file = get_test_file('example-resource.warc.gz')
+    tmp_file = tmp_path / "output.warc.gz"
+    with open(test_file, "rb") as input, open(tmp_file, "wb") as output:
+        recompressor = StreamRecompressor(input, output, verbose=True)
+        count = recompressor.decompress_recompress()
+    assert count == 3


### PR DESCRIPTION
The `Recompressor` so far was working on files.
With these changes:
- Tests are added
- Duplicated code in `recompress()` and `load_and_write()` resp. `decompress_and_recompress()` is deduplicated.
- The file handling and operations in streams/file-like-objects is separated.
- `_load_and_write_stream()` and `_decompress_and_recompress_stream()` work on streams
- `StreamRecompressor` is introduced to work purely on streams:
  - `recompress()` handles properly compressed or uncompressed streams
  - `decompress_recompress()` handles any gzip compressed stream

The pull request is not yet organized in nice commits. If it is acceptable in general, I will rebase it and rework the commits, if required. If you prefer nicer commits for review, please tell me.