### PR TITLE
Handle deprecation of naive datetime functions like utcnow()

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   push:
-    branches:
-    - aster
   pull_request:
 
 jobs:

--- a/warcio/recordbuilder.py
+++ b/warcio/recordbuilder.py
@@ -153,7 +153,7 @@ class RecordBuilder(object):
 
     @classmethod
     def _make_warc_date(cls, use_micros=False):
-        return datetime_to_iso_date(datetime.now(timezone.utc), use_micros=use_micros)
+        return datetime_to_iso_date(datetime.now(timezone.utc).replace(tzinfo=None), use_micros=use_micros)
 
     def ensure_digest(self, record, block=True, payload=True):
         if block:

--- a/warcio/recordbuilder.py
+++ b/warcio/recordbuilder.py
@@ -1,7 +1,7 @@
-import datetime
 import six
 import tempfile
 
+from datetime import datetime, timezone
 from io import BytesIO
 
 from warcio.recordloader import ArcWarcRecord, ArcWarcRecordLoader
@@ -153,7 +153,7 @@ class RecordBuilder(object):
 
     @classmethod
     def _make_warc_date(cls, use_micros=False):
-        return datetime_to_iso_date(datetime.datetime.utcnow(), use_micros=use_micros)
+        return datetime_to_iso_date(datetime.now(timezone.utc), use_micros=use_micros)
 
     def ensure_digest(self, record, block=True, payload=True):
         if block:

--- a/warcio/timeutils.py
+++ b/warcio/timeutils.py
@@ -366,7 +366,7 @@ def timestamp_to_sec(string):
     1420070399
     """
 
-    dt = timestamp_to_datetime(string, tzinfo=timezone.utc)
+    dt = timestamp_to_datetime(string, aware=True)
     return calendar.timegm(dt.utctimetuple())
 
 

--- a/warcio/timeutils.py
+++ b/warcio/timeutils.py
@@ -63,9 +63,9 @@ def iso_date_to_datetime(string, aware=False):
         nums[6] = nums[6][:6]
         nums[6] += PAD_MICRO[len(nums[6]):]
 
-    tz_info = None
+    tzinfo = None
     if aware:
-        tz_info = timezone.utc
+        tzinfo = timezone.utc
 
     the_datetime = datetime(*(int(num) for num in nums), tzinfo=tzinfo)
     return the_datetime
@@ -79,9 +79,9 @@ def http_date_to_datetime(string, aware=False):
     >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT', aware=True)
     datetime.datetime(2013, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
     """
-    tz_info = None
+    tzinfo = None
     if aware:
-        tz_info = timezone.utc
+        tzinfo = timezone.utc
 
     return datetime(*parsedate(string)[:6], tzinfo=tzinfo)
 

--- a/warcio/timeutils.py
+++ b/warcio/timeutils.py
@@ -25,7 +25,7 @@ PAD_6_UP =    '299912'
 PAD_MICRO =   '000000'
 
 
-def iso_date_to_datetime(string, tzinfo: timezone = None):
+def iso_date_to_datetime(string, aware=False):
     """
     >>> iso_date_to_datetime('2013-12-26T10:11:12Z')
     datetime.datetime(2013, 12, 26, 10, 11, 12)
@@ -48,10 +48,10 @@ def iso_date_to_datetime(string, tzinfo: timezone = None):
     >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z')
     datetime.datetime(2013, 12, 26, 10, 11, 12)
 
-    >>> iso_date_to_datetime('2013-12-26T10:11:12Z', tzinfo=timezone.utc)
+    >>> iso_date_to_datetime('2013-12-26T10:11:12Z', aware=True)
     datetime.datetime(2013, 12, 26, 10, 11, 12, tzinfo=datetime.timezone.utc)
 
-    >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z', tzinfo=timezone.utc)
+    >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z', aware=True)
     datetime.datetime(2013, 12, 26, 10, 11, 12, tzinfo=datetime.timezone.utc)
     """
 
@@ -63,18 +63,26 @@ def iso_date_to_datetime(string, tzinfo: timezone = None):
         nums[6] = nums[6][:6]
         nums[6] += PAD_MICRO[len(nums[6]):]
 
+    tz_info = None
+    if aware:
+        tz_info = timezone.utc
+
     the_datetime = datetime(*(int(num) for num in nums), tzinfo=tzinfo)
     return the_datetime
 
 
-def http_date_to_datetime(string, tzinfo: timezone = None):
+def http_date_to_datetime(string, aware=False):
     """
     >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT')
     datetime.datetime(2013, 12, 26, 9, 50, 10)
 
-    >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT', tzinfo=timezone.utc)
+    >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT', aware=True)
     datetime.datetime(2013, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
     """
+    tz_info = None
+    if aware:
+        tz_info = timezone.utc
+
     return datetime(*parsedate(string)[:6], tzinfo=tzinfo)
 
 
@@ -212,7 +220,7 @@ def pad_timestamp(string, pad_str=PAD_6_UP):
     return string
 
 
-def timestamp_to_datetime(string, tzinfo: timezone = None):
+def timestamp_to_datetime(string, aware=False):
     """
     # >14-digit -- rest ignored
     >>> timestamp_to_datetime('2014122609501011')
@@ -295,15 +303,15 @@ def timestamp_to_datetime(string, tzinfo: timezone = None):
     datetime.datetime(2010, 12, 31, 23, 59, 59)
 
     # 14-digit with tzinfo
-    >>> timestamp_to_datetime('20141226095010', tzinfo=timezone.utc)
+    >>> timestamp_to_datetime('20141226095010', aware=True)
     datetime.datetime(2014, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
 
     # 6-digit padding with tzinfo
-    >>> timestamp_to_datetime('201410', tzinfo=timezone.utc)
+    >>> timestamp_to_datetime('201410', aware=True)
     datetime.datetime(2014, 10, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
 
     # not a number! with tzinfo
-    >>> timestamp_to_datetime('2010abc', tzinfo=timezone.utc)
+    >>> timestamp_to_datetime('2010abc', aware=True)
     datetime.datetime(2010, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
 
     """
@@ -332,6 +340,10 @@ def timestamp_to_datetime(string, tzinfo: timezone = None):
     hour = extract(string, 8, 10, 0, 23)
     minute = extract(string, 10, 12, 0, 59)
     second = extract(string, 12, 14, 0, 59)
+
+    tzinfo = None
+    if aware:
+        tzinfo = timezone.utc
 
     return datetime(year=year,
                              month=month,

--- a/warcio/timeutils.py
+++ b/warcio/timeutils.py
@@ -354,7 +354,8 @@ def timestamp_to_sec(string):
     1420070399
     """
 
-    return calendar.timegm(timestamp_to_datetime(string).utctimetuple())
+    dt = timestamp_to_datetime(string, tzinfo=timezone.utc)
+    return calendar.timegm(dt.utctimetuple())
 
 
 def sec_to_timestamp(secs):
@@ -366,7 +367,7 @@ def sec_to_timestamp(secs):
     '20141231235959'
     """
 
-    return datetime_to_timestamp(datetime.utcfromtimestamp(secs))
+    return datetime_to_timestamp(datetime.fromtimestamp(secs, timezone.utc))
 
 
 def timestamp_to_http_date(string):

--- a/warcio/timeutils.py
+++ b/warcio/timeutils.py
@@ -25,7 +25,7 @@ PAD_6_UP =    '299912'
 PAD_MICRO =   '000000'
 
 
-def iso_date_to_datetime(string, aware=False):
+def iso_date_to_datetime(string, tz_aware=False):
     """
     >>> iso_date_to_datetime('2013-12-26T10:11:12Z')
     datetime.datetime(2013, 12, 26, 10, 11, 12)
@@ -48,10 +48,10 @@ def iso_date_to_datetime(string, aware=False):
     >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z')
     datetime.datetime(2013, 12, 26, 10, 11, 12)
 
-    >>> iso_date_to_datetime('2013-12-26T10:11:12Z', aware=True)
+    >>> iso_date_to_datetime('2013-12-26T10:11:12Z', tz_aware=True)
     datetime.datetime(2013, 12, 26, 10, 11, 12, tzinfo=datetime.timezone.utc)
 
-    >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z', aware=True)
+    >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z', tz_aware=True)
     datetime.datetime(2013, 12, 26, 10, 11, 12, tzinfo=datetime.timezone.utc)
     """
 
@@ -64,23 +64,23 @@ def iso_date_to_datetime(string, aware=False):
         nums[6] += PAD_MICRO[len(nums[6]):]
 
     tzinfo = None
-    if aware:
+    if tz_aware:
         tzinfo = timezone.utc
 
     the_datetime = datetime(*(int(num) for num in nums), tzinfo=tzinfo)
     return the_datetime
 
 
-def http_date_to_datetime(string, aware=False):
+def http_date_to_datetime(string, tz_aware=False):
     """
     >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT')
     datetime.datetime(2013, 12, 26, 9, 50, 10)
 
-    >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT', aware=True)
+    >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT', tz_aware=True)
     datetime.datetime(2013, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
     """
     tzinfo = None
-    if aware:
+    if tz_aware:
         tzinfo = timezone.utc
 
     return datetime(*parsedate(string)[:6], tzinfo=tzinfo)
@@ -220,7 +220,7 @@ def pad_timestamp(string, pad_str=PAD_6_UP):
     return string
 
 
-def timestamp_to_datetime(string, aware=False):
+def timestamp_to_datetime(string, tz_aware=False):
     """
     # >14-digit -- rest ignored
     >>> timestamp_to_datetime('2014122609501011')
@@ -303,15 +303,15 @@ def timestamp_to_datetime(string, aware=False):
     datetime.datetime(2010, 12, 31, 23, 59, 59)
 
     # 14-digit with tzinfo
-    >>> timestamp_to_datetime('20141226095010', aware=True)
+    >>> timestamp_to_datetime('20141226095010', tz_aware=True)
     datetime.datetime(2014, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
 
     # 6-digit padding with tzinfo
-    >>> timestamp_to_datetime('201410', aware=True)
+    >>> timestamp_to_datetime('201410', tz_aware=True)
     datetime.datetime(2014, 10, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
 
     # not a number! with tzinfo
-    >>> timestamp_to_datetime('2010abc', aware=True)
+    >>> timestamp_to_datetime('2010abc', tz_aware=True)
     datetime.datetime(2010, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
 
     """
@@ -342,7 +342,7 @@ def timestamp_to_datetime(string, aware=False):
     second = extract(string, 12, 14, 0, 59)
 
     tzinfo = None
-    if aware:
+    if tz_aware:
         tzinfo = timezone.utc
 
     return datetime(year=year,
@@ -366,7 +366,7 @@ def timestamp_to_sec(string):
     1420070399
     """
 
-    dt = timestamp_to_datetime(string, aware=True)
+    dt = timestamp_to_datetime(string, tz_aware=True)
     return calendar.timegm(dt.utctimetuple())
 
 

--- a/warcio/timeutils.py
+++ b/warcio/timeutils.py
@@ -5,9 +5,9 @@ datetime, iso date and 14-digit timestamp
 
 import re
 import time
-import datetime
 import calendar
 
+from datetime import datetime, timezone
 from email.utils import parsedate, formatdate
 
 #=================================================================
@@ -25,7 +25,7 @@ PAD_6_UP =    '299912'
 PAD_MICRO =   '000000'
 
 
-def iso_date_to_datetime(string):
+def iso_date_to_datetime(string, tzinfo: timezone = None):
     """
     >>> iso_date_to_datetime('2013-12-26T10:11:12Z')
     datetime.datetime(2013, 12, 26, 10, 11, 12)
@@ -47,6 +47,12 @@ def iso_date_to_datetime(string):
 
     >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z')
     datetime.datetime(2013, 12, 26, 10, 11, 12)
+
+    >>> iso_date_to_datetime('2013-12-26T10:11:12Z', tzinfo=timezone.utc)
+    datetime.datetime(2013, 12, 26, 10, 11, 12, tzinfo=datetime.timezone.utc)
+
+    >>> iso_date_to_datetime('2013-12-26T10:11:12.000000Z', tzinfo=timezone.utc)
+    datetime.datetime(2013, 12, 26, 10, 11, 12, tzinfo=datetime.timezone.utc)
     """
 
     nums = DATE_TIMESPLIT.split(string)
@@ -57,21 +63,24 @@ def iso_date_to_datetime(string):
         nums[6] = nums[6][:6]
         nums[6] += PAD_MICRO[len(nums[6]):]
 
-    the_datetime = datetime.datetime(*(int(num) for num in nums))
+    the_datetime = datetime(*(int(num) for num in nums), tzinfo=tzinfo)
     return the_datetime
 
 
-def http_date_to_datetime(string):
+def http_date_to_datetime(string, tzinfo: timezone = None):
     """
     >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT')
     datetime.datetime(2013, 12, 26, 9, 50, 10)
+
+    >>> http_date_to_datetime('Thu, 26 Dec 2013 09:50:10 GMT', tzinfo=timezone.utc)
+    datetime.datetime(2013, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
     """
-    return datetime.datetime(*parsedate(string)[:6])
+    return datetime(*parsedate(string)[:6], tzinfo=tzinfo)
 
 
 def datetime_to_http_date(the_datetime):
     """
-    >>> datetime_to_http_date(datetime.datetime(2013, 12, 26, 9, 50, 10))
+    >>> datetime_to_http_date(datetime(2013, 12, 26, 9, 50, 10))
     'Thu, 26 Dec 2013 09:50:10 GMT'
 
     # Verify inverses
@@ -87,19 +96,19 @@ def datetime_to_http_date(the_datetime):
 
 def datetime_to_iso_date(the_datetime, use_micros=False):
     """
-    >>> datetime_to_iso_date(datetime.datetime(2013, 12, 26, 10, 11, 12))
+    >>> datetime_to_iso_date(datetime(2013, 12, 26, 10, 11, 12))
     '2013-12-26T10:11:12Z'
 
-    >>> datetime_to_iso_date(datetime.datetime(2013, 12, 26, 10, 11, 12, 456789))
+    >>> datetime_to_iso_date(datetime(2013, 12, 26, 10, 11, 12, 456789))
     '2013-12-26T10:11:12Z'
 
-    >>> datetime_to_iso_date(datetime.datetime(2013, 12, 26, 10, 11, 12), use_micros=True)
+    >>> datetime_to_iso_date(datetime(2013, 12, 26, 10, 11, 12), use_micros=True)
     '2013-12-26T10:11:12Z'
 
-    >>> datetime_to_iso_date(datetime.datetime(2013, 12, 26, 10, 11, 12, 456789), use_micros=True)
+    >>> datetime_to_iso_date(datetime(2013, 12, 26, 10, 11, 12, 456789), use_micros=True)
     '2013-12-26T10:11:12.456789Z'
 
-    >>> datetime_to_iso_date(datetime.datetime(2013, 12, 26, 10, 11, 12, 1), use_micros=True)
+    >>> datetime_to_iso_date(datetime(2013, 12, 26, 10, 11, 12, 1), use_micros=True)
     '2013-12-26T10:11:12.000001Z'
 
     """
@@ -112,7 +121,7 @@ def datetime_to_iso_date(the_datetime, use_micros=False):
 
 def datetime_to_timestamp(the_datetime):
     """
-    >>> datetime_to_timestamp(datetime.datetime(2013, 12, 26, 10, 11, 12))
+    >>> datetime_to_timestamp(datetime(2013, 12, 26, 10, 11, 12))
     '20131226101112'
     """
 
@@ -124,7 +133,7 @@ def timestamp_now():
     >>> len(timestamp_now())
     14
     """
-    return datetime_to_timestamp(datetime.datetime.utcnow())
+    return datetime_to_timestamp(datetime.now(timezone.utc))
 
 
 def timestamp20_now():
@@ -139,7 +148,7 @@ def timestamp20_now():
     20
 
     """
-    now = datetime.datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return now.strftime('%Y%m%d%H%M%S%f')
 
 
@@ -203,7 +212,7 @@ def pad_timestamp(string, pad_str=PAD_6_UP):
     return string
 
 
-def timestamp_to_datetime(string):
+def timestamp_to_datetime(string, tzinfo: timezone = None):
     """
     # >14-digit -- rest ignored
     >>> timestamp_to_datetime('2014122609501011')
@@ -285,6 +294,18 @@ def timestamp_to_datetime(string):
     >>> timestamp_to_datetime('2010abc')
     datetime.datetime(2010, 12, 31, 23, 59, 59)
 
+    # 14-digit with tzinfo
+    >>> timestamp_to_datetime('20141226095010', tzinfo=timezone.utc)
+    datetime.datetime(2014, 12, 26, 9, 50, 10, tzinfo=datetime.timezone.utc)
+
+    # 6-digit padding with tzinfo
+    >>> timestamp_to_datetime('201410', tzinfo=timezone.utc)
+    datetime.datetime(2014, 10, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
+
+    # not a number! with tzinfo
+    >>> timestamp_to_datetime('2010abc', tzinfo=timezone.utc)
+    datetime.datetime(2010, 12, 31, 23, 59, 59, tzinfo=datetime.timezone.utc)
+
     """
 
     # pad to 6 digits
@@ -312,12 +333,13 @@ def timestamp_to_datetime(string):
     minute = extract(string, 10, 12, 0, 59)
     second = extract(string, 12, 14, 0, 59)
 
-    return datetime.datetime(year=year,
+    return datetime(year=year,
                              month=month,
                              day=day,
                              hour=hour,
                              minute=minute,
-                             second=second)
+                             second=second,
+                             tzinfo=tzinfo)
 
     #return time.strptime(pad_timestamp(string), TIMESTAMP_14)
 
@@ -344,7 +366,7 @@ def sec_to_timestamp(secs):
     '20141231235959'
     """
 
-    return datetime_to_timestamp(datetime.datetime.utcfromtimestamp(secs))
+    return datetime_to_timestamp(datetime.utcfromtimestamp(secs))
 
 
 def timestamp_to_http_date(string):


### PR DESCRIPTION
Fixes #163 

The approach taken follows the advice in https://github.com/webrecorder/warcio/issues/163#issuecomment-2313410986 of returning naive datetimes by default, but (and this is a little different than suggested) allowing callers to specify `tz_aware=True` to receive an aware datetime with `tzinfo=datetime.timezone.utc`. This should prevent comparison errors between naive and aware datetimes for now while giving us a clear path forward if and when naive datetimes are fully deprecated in a future Python version.