### PR TITLE
Remove `six` dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ the format (ARC or WARC), record type, the record headers, http headers
 
 .. code:: python
 
-    class ArcWarcRecord(object):
+    class ArcWarcRecord:
         def __init__(self, *args):
             (self.format, self.rec_type, self.rec_headers, self.raw_stream,
              self.http_headers, self.content_type, self.length) = args

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,7 @@ Background
 
 This library provides a fast, standalone way to read and write `WARC
 Format <https://en.wikipedia.org/wiki/Web_ARChive>`__ commonly used in
-web archives. Python 3.7+ (minimally only needing
-`six <https://pythonhosted.org/six/>`__ as an external dependency)
+web archives. Python 3.7+.
 
 warcio supports reading and writing of WARC files compliant with both the `WARC 1.0 <http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1_latestdraft.pdf>`__
 and `WARC 1.1 <http://bibnum.bnf.fr/WARC/WARC_ISO_28500_version1-1_latestdraft.pdf>`__ ISO standards.

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setup(
     provides=[
         'warcio',
         ],
-    install_requires=[
-        'six',
-        ],
+    install_requires=[],
     zip_safe=True,
     entry_points="""
         [console_scripts]

--- a/test/test_archiveiterator.py
+++ b/test/test_archiveiterator.py
@@ -16,7 +16,7 @@ import subprocess
 
 
 #==============================================================================
-class TestArchiveIterator(object):
+class TestArchiveIterator:
     def _load_archive(self, filename, offset=0, cls=ArchiveIterator,
                      errs_expected=0, **kwargs):
 

--- a/test/test_bufferedreaders.py
+++ b/test/test_bufferedreaders.py
@@ -101,8 +101,6 @@ from warcio.limitreader import LimitReader
 
 from contextlib import closing
 
-import six
-
 import zlib
 import pytest
 
@@ -177,7 +175,7 @@ def test_err_chunk_cut_off():
 
 
 def print_str(string):
-    return string.decode('utf-8') if six.PY3 else string
+    return string.decode('utf-8')
 
 
 

--- a/test/test_capture_http.py
+++ b/test/test_capture_http.py
@@ -21,7 +21,7 @@ from warcio.warcwriter import BufferWARCWriter, WARCWriter
 
 
 # ==================================================================
-class TestCaptureHttpBin(object):
+class TestCaptureHttpBin:
     @classmethod
     def setup_class(cls):
         from httpbin import app as httpbin_app

--- a/test/test_check_digest_examples.py
+++ b/test/test_check_digest_examples.py
@@ -21,7 +21,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('test_filename', files)
 
 
-class TestExamplesDigest(object):
+class TestExamplesDigest:
     def check_helper(self, args, expected_exit_value, capsys):
         exit_value = None
         try:

--- a/test/test_limitreader.py
+++ b/test/test_limitreader.py
@@ -3,7 +3,7 @@ from contextlib import closing
 
 from io import BytesIO
 
-class TestLimitReader(object):
+class TestLimitReader:
     def test_limit_reader_1(self):
         assert b'abcdefghji' == LimitReader(BytesIO(b'abcdefghjiklmnopqrstuvwxyz'), 10).read(26)
 

--- a/test/test_statusandheaders.py
+++ b/test/test_statusandheaders.py
@@ -91,7 +91,7 @@ StatusAndHeaders(protocol = 'HTTP/1.0', statusline = '204 empty', headers = [('C
 
 
 from warcio.statusandheaders import StatusAndHeadersParser, StatusAndHeaders
-from six import StringIO
+from io import StringIO
 import pytest
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -77,14 +77,14 @@ class TestUtils(object):
     def test_open_exclusive(self):
         temp_dir = tempfile.mkdtemp('warctest')
         full_name = os.path.join(temp_dir, 'foo.txt')
-        with utils.open(full_name, 'xb') as fh:
+        with open(full_name, 'xb') as fh:
             fh.write(b'test\r\nfoo')
 
         with pytest.raises(OSError):
-            with utils.open(full_name, 'xb') as fh:
+            with open(full_name, 'xb') as fh:
                 fh.write(b'test\r\nfoo')
 
-        with utils.open(full_name, 'rb') as fh:
+        with open(full_name, 'rb') as fh:
             assert fh.read() == b'test\r\nfoo'
 
         os.remove(full_name)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -14,7 +14,7 @@ except ImportError:
     pass
 
 
-class TestUtils(object):
+class TestUtils:
     def test_headers_to_str_headers(self):
         result = [('foo', 'bar'), ('baz', 'barf')]
 

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -560,7 +560,7 @@ def record_sampler(request):
 
 
 # ============================================================================
-class TestWarcWriter(object):
+class TestWarcWriter:
     @classmethod
     def _validate_record_content_len(cls, stream):
         for record in ArchiveIterator(stream, no_record_parse=True):

--- a/warcio/archiveiterator.py
+++ b/warcio/archiveiterator.py
@@ -6,7 +6,6 @@ from warcio.recordloader import ArcWarcRecordLoader
 from warcio.utils import BUFF_SIZE
 
 import sys
-import six
 
 # ============================================================================
 class UnseekableYetTellable:
@@ -23,7 +22,7 @@ class UnseekableYetTellable:
         return result
 
 # ============================================================================
-class ArchiveIterator(six.Iterator):
+class ArchiveIterator:
     """ Iterate over records in WARC and ARC files, both gzip chunk
     compressed and uncompressed
 
@@ -91,7 +90,7 @@ class ArchiveIterator(six.Iterator):
         return self.the_iter
 
     def __next__(self):
-        return six.next(self.the_iter)
+        return next(self.the_iter)
 
     def close(self):
         self.record = None

--- a/warcio/bufferedreaders.py
+++ b/warcio/bufferedreaders.py
@@ -37,7 +37,7 @@ def try_brotli_init():
 
 
 #=================================================================
-class BufferedReader(object):
+class BufferedReader:
     """
     A wrapping line reader which wraps an existing reader.
     Read operations operate on underlying buffer, which is filled to

--- a/warcio/capture_http.py
+++ b/warcio/capture_http.py
@@ -2,13 +2,13 @@ import threading
 
 from io import BytesIO
 
-from six.moves import http_client as httplib
+import http.client as httplib
 
 from contextlib import contextmanager
 
 from array import array
 
-from warcio.utils import to_native_str, BUFF_SIZE, open
+from warcio.utils import to_native_str, BUFF_SIZE
 from warcio.warcwriter import WARCWriter, BufferWARCWriter
 
 from tempfile import SpooledTemporaryFile

--- a/warcio/capture_http.py
+++ b/warcio/capture_http.py
@@ -19,7 +19,7 @@ orig_connection = httplib.HTTPConnection
 
 
 # ============================================================================
-class RecordingStream(object):
+class RecordingStream:
     def __init__(self, fp, recorder):
         self.fp = fp
         self.recorder = recorder
@@ -130,7 +130,7 @@ class RecordingHTTPConnection(httplib.HTTPConnection):
 
 
 # ============================================================================
-class RequestRecorder(object):
+class RequestRecorder:
     def __init__(self, writer, filter_func=None, record_ip=True):
         self.writer = writer
         self.filter_func = filter_func

--- a/warcio/checker.py
+++ b/warcio/checker.py
@@ -11,7 +11,7 @@ def _read_entire_stream(stream):
             break
 
 
-class Checker(object):
+class Checker:
     def __init__(self, cmd):
         self.inputs = cmd.inputs
         self.verbose = cmd.verbose

--- a/warcio/digestverifyingreader.py
+++ b/warcio/digestverifyingreader.py
@@ -7,7 +7,7 @@ from warcio.exceptions import ArchiveLoadFailed
 
 
 # ============================================================================
-class DigestChecker(object):
+class DigestChecker:
     def __init__(self, kind=None):
         self._problem = []
         self._passed = None

--- a/warcio/extractor.py
+++ b/warcio/extractor.py
@@ -5,7 +5,7 @@ import sys
 
 
 # ============================================================================
-class Extractor(object):
+class Extractor:
     READ_SIZE = BUFF_SIZE * 4
 
     def __init__(self, filename, offset):

--- a/warcio/indexer.py
+++ b/warcio/indexer.py
@@ -9,7 +9,7 @@ from warcio.utils import open_or_default
 
 
 # ============================================================================
-class Indexer(object):
+class Indexer:
     field_names = {}
 
     def __init__(self, fields, inputs, output, verify_http=False):

--- a/warcio/limitreader.py
+++ b/warcio/limitreader.py
@@ -1,5 +1,5 @@
 # ============================================================================
-class LimitReader(object):
+class LimitReader:
     """
     A reader which will not read more than specified limit
     """

--- a/warcio/recompressor.py
+++ b/warcio/recompressor.py
@@ -11,7 +11,7 @@ import sys
 
 
 # ============================================================================
-class Recompressor(object):
+class Recompressor:
     def __init__(self, filename, output, verbose=False):
         self.filename = filename
         self.output = output

--- a/warcio/recordbuilder.py
+++ b/warcio/recordbuilder.py
@@ -9,7 +9,7 @@ from warcio.timeutils import datetime_to_iso_date
 from warcio.utils import to_native_str, BUFF_SIZE, Digester
 
 #=================================================================
-class RecordBuilder(object):
+class RecordBuilder:
     REVISIT_PROFILE = 'http://netpreserve.org/warc/1.0/revisit/identical-payload-digest'
     REVISIT_PROFILE_1_1 = 'http://netpreserve.org/warc/1.1/revisit/identical-payload-digest'
 

--- a/warcio/recordbuilder.py
+++ b/warcio/recordbuilder.py
@@ -1,4 +1,3 @@
-import six
 import tempfile
 
 from datetime import datetime, timezone
@@ -44,7 +43,7 @@ class RecordBuilder(object):
         warc_headers.add_header('WARC-Date', self.curr_warc_date())
 
         warcinfo = BytesIO()
-        for name, value in six.iteritems(info):
+        for name, value in info.items():
             if not value:
                 continue
 

--- a/warcio/recordloader.py
+++ b/warcio/recordloader.py
@@ -10,8 +10,6 @@ from warcio.bufferedreaders import BufferedReader, ChunkedDataReader
 
 from warcio.timeutils import timestamp_to_iso_date
 
-from six.moves import zip
-
 import logging
 logger = logging.getLogger(__name__)
 

--- a/warcio/recordloader.py
+++ b/warcio/recordloader.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 #=================================================================
-class ArcWarcRecord(object):
+class ArcWarcRecord:
     def __init__(self, *args, **kwargs):
         (self.format, self.rec_type, self.rec_headers, self.raw_stream,
          self.http_headers, self.content_type, self.length) = args
@@ -43,7 +43,7 @@ class ArcWarcRecord(object):
 
 
 #=================================================================
-class ArcWarcRecordLoader(object):
+class ArcWarcRecordLoader:
     WARC_TYPES = ['WARC/1.1', 'WARC/1.0', 'WARC/0.17', 'WARC/0.18']
 
     HTTP_TYPES = ['HTTP/1.0', 'HTTP/1.1']
@@ -267,7 +267,7 @@ class ArcWarcRecordLoader(object):
 
 
 #=================================================================
-class ARCHeadersParser(object):
+class ARCHeadersParser:
     # ARC 1.0 headers
     ARC_HEADERS = ["uri", "ip-address", "archive-date",
                        "content-type", "length"]

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -2,12 +2,10 @@
 Representation and parsing of HTTP-style status + headers
 """
 
-from six.moves import range
-from six import iteritems
 from warcio.utils import to_native_str, headers_to_str_headers
 import uuid
 
-from six.moves.urllib.parse import quote
+from urllib.parse import quote
 import re
 
 

--- a/warcio/statusandheaders.py
+++ b/warcio/statusandheaders.py
@@ -10,7 +10,7 @@ import re
 
 
 #=================================================================
-class StatusAndHeaders(object):
+class StatusAndHeaders:
     ENCODE_HEADER_RX = re.compile(r'[=]["\']?([^;"]+)["\']?(?=[;]?)')
     """
     Representation of parsed http-style status line and headers
@@ -222,7 +222,7 @@ def _strip_count(string, total_read):
 
 
 #=================================================================
-class StatusAndHeadersParser(object):
+class StatusAndHeadersParser:
     """
     Parser which consumes a stream support readline() to read
     status and headers and return a StatusAndHeaders object

--- a/warcio/utils.py
+++ b/warcio/utils.py
@@ -58,7 +58,7 @@ def headers_to_str_headers(headers):
 
 
 # ============================================================================
-class Digester(object):
+class Digester:
     def __init__(self, type_='sha1'):
         self.type_ = type_
         self.digester = hashlib.new(type_)

--- a/warcio/utils.py
+++ b/warcio/utils.py
@@ -1,13 +1,9 @@
-import six
 import os
 from contextlib import contextmanager
 import base64
 import hashlib
 
-try:
-    import collections.abc as collections_abc  # only works on python 3.3+
-except ImportError:  #pragma: no cover
-    import collections as collections_abc
+import collections.abc
 
 BUFF_SIZE = 16384
 
@@ -17,10 +13,8 @@ def to_native_str(value, encoding='utf-8'):
     if isinstance(value, str):
         return value
 
-    if six.PY3 and isinstance(value, six.binary_type):  #pragma: no cover
+    if isinstance(value, bytes):
         return value.decode(encoding)
-    elif six.PY2 and isinstance(value, six.text_type):  #pragma: no cover
-        return value.encode(encoding)
     else:
         return value
 
@@ -48,19 +42,16 @@ def headers_to_str_headers(headers):
     '''
     ret = []
 
-    if isinstance(headers, collections_abc.Mapping):
+    if isinstance(headers, collections.abc.Mapping):
         h = headers.items()
     else:
         h = headers
 
-    if six.PY2:  #pragma: no cover
-        return h
-
     for tup in h:
         k, v = tup
-        if isinstance(k, six.binary_type):
+        if isinstance(k, bytes):
             k = k.decode('iso-8859-1')
-        if isinstance(v, six.binary_type):
+        if isinstance(v, bytes):
             v = v.decode('iso-8859-1')
         ret.append((k, v))
     return ret
@@ -77,25 +68,3 @@ class Digester(object):
 
     def __str__(self):
         return self.type_ + ':' + to_native_str(base64.b32encode(self.digester.digest()))
-
-
-#=============================================================================
-sys_open = open
-
-def open(filename, mode='r', **kwargs):  #pragma: no cover
-    """
-    open() which supports exclusive mode 'x' in python < 3.3
-    """
-    if six.PY3 or 'x' not in mode:
-        return sys_open(filename, mode, **kwargs)
-
-    flags = os.O_EXCL | os.O_CREAT | os.O_WRONLY
-    if 'b' in mode and hasattr(os, 'O_BINARY'):
-        flags |= os.O_BINARY
-
-    fd = os.open(filename, flags)
-    mode = mode.replace('x', 'w')
-    return os.fdopen(fd, mode, 0x664)
-
-
-

--- a/warcio/warcwriter.py
+++ b/warcio/warcwriter.py
@@ -110,7 +110,7 @@ class BaseWARCWriter(RecordBuilder):
 
 
 # ============================================================================
-class GzippingWrapper(object):
+class GzippingWrapper:
     def __init__(self, out):
         self.compressor = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS + 16)
         self.out = out


### PR DESCRIPTION
Python 2.7 compatibility was dropped in #116, so `six` is not needed anymore.