### PR TITLE
Update publish_pypi workflow actions to resolve deprecation and security notices

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -26,7 +26,7 @@ jobs:
         run: python setup.py sdist bdist_wheel --universal
 
       - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Build Dist
         run: python setup.py sdist bdist_wheel --universal
 
-      - name: Publish package to TestPyPI
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
Will resolve deprecation and security notices in publish workflow CI runs.

- Bumps checkout and setup-python action versions
- Modifies reference for https://github.com/pypa/gh-action-pypi-publish action to release/v1 as recommended in their repo
- Fixes inaccurate step name (which implied action published to test PyPI when it actually publishes to PyPI)