### PR TITLE
Document HF Buckets as an s3 alternative for Common Crawl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -463,8 +463,8 @@ In Python code:
 
     # Read WARC records directly from HF Buckets
     with fsspec_open(
-        'hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2025-51/'
-        'segments/1764871645602.73/warc/CC-MAIN-20251215005813-20251215035813-00995.warc.gz',
+        'hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/'
+        'segments/1775805908305.14/warc/CC-MAIN-20260410081153-20260410111153-00000.warc.gz',
         'rb'
     ) as stream:
         for record in ArchiveIterator(stream):
@@ -514,7 +514,7 @@ To open files returned by ``ls()``, prepend the protocol:
 
     files = hffs.ls('hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/segments/1775805908305.14/warc/')
     for file_path in files[:1]:  # files is like 'buckets/commoncrawl/.../file.warc.gz'
-        with fsspec_open('hf://' + file_path, 'rb') as fh:
+        with fsspec_open('hf://' + file_path['name'], 'rb') as fh:
             for record in ArchiveIterator(fh):
                 ...
 

--- a/README.rst
+++ b/README.rst
@@ -408,8 +408,8 @@ Remote File System Support
 --------------------------
 
 The library supports reading and writing WARC files to a remote file system such as HTTP or S3.
-To enable this feature, you need to install the optional dependencies with ``pip install warcio[s3]``.
-For example, you can then read WARC files directly from `Common Crawl's S3 bucket <https://commoncrawl.org/get-started>`_.
+To enable this feature, you need to install the optional dependencies with ``pip install warcio[s3]`` or ``pip install warcio[hf]``.
+For example, you can then read WARC files directly from `Common Crawl's S3 or HF buckets <https://commoncrawl.org/get-started>`_.
 
 This command will read a WARC file from outside AWS, using https,  and print the first 10 records to stdin:
 
@@ -428,6 +428,95 @@ This command will read a WARC file from from inside AWS, using S3, and print the
 This is implemented with `fsspec <https://filesystem-spec.readthedocs.io/en/latest/index.html>`_.
 By default, only HTTP, S3, and other built-in fsspec file systems are integrated.
 To support other file systems, you need to install the corresponding fsspec dependencies such as ``fsspec[gcs]`` for Google Cloud storage or ``fsspec[all]`` for all available file systems.
+
+Common Crawl on Hugging Face Buckets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As of 2025, Common Crawl dumps are also hosted on `Hugging Face Buckets <https://huggingface.co/buckets/commoncrawl>`_,
+proving a cheaper and more accessible alternative to AWS S3. Unlike S3, which may restrict access to
+AWS machines in the same region due to fees for inter-region data transfer (you have to send requests which are charged as outgoing traffic).
+CC dumps on HF Buckets are accessible from multiple cloud providers and regions
+using the ``hf://`` protocol (see the CDN section `here <https://huggingface.co/buckets/commoncrawl/commoncrawl>`_).
+
+To use HF Buckets, install the optional ``hf`` extra:
+
+::
+
+    pip install warcio[hf]
+
+Then use the ``hf://`` protocol prefix in your file paths:
+
+::
+
+    # Index a WARC file from HF Buckets
+    warcio index hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2025-51/segments/1764871645602.73/warc/CC-MAIN-20251215005813-20251215035813-00995.warc.gz | head -n 10
+
+    # Check integrity of a WARC file from HF Buckets
+    warcio check -v hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2025-51/segments/1764871645602.73/warc/CC-MAIN-20251215005813-20251215035813-00995.warc.gz
+
+In Python code:
+
+.. code:: python
+
+    from warcio.archiveiterator import ArchiveIterator
+    from warcio.utils import fsspec_open
+
+    # Read WARC records directly from HF Buckets
+    with fsspec_open(
+        'hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2025-51/'
+        'segments/1764871645602.73/warc/CC-MAIN-20251215005813-20251215035813-00995.warc.gz',
+        'rb'
+    ) as stream:
+        for record in ArchiveIterator(stream):
+            if record.rec_type == 'response':
+                print(record.rec_headers.get_header('WARC-Target-URI'))
+
+The ``hf://`` protocol is powered by `HfFileSystem <https://huggingface.co/docs/huggingface_hub/en/guides/hf_file_system>`_
+from the ``huggingface_hub`` library, which integrates seamlessly with fsspec.
+For authenticated access (e.g., private repos), login using ``hf auth login`` or pass the ``token`` argument:
+
+.. code:: python
+
+    with fsspec_open(
+        'hf://username/repo/file.warc.gz',
+        'rb',
+        token='hf_xxxxxxxxxxxxxxxxxxxx'
+    ) as stream:
+        ...
+
+Common Crawl path structure on HF Buckets:
+
+``hf://buckets/commoncrawl/commoncrawl/crawl-data/<crawl-name>/<path>``
+
+You can explore the available data using the `huggingface_hub <https://huggingface.co/docs/huggingface_hub>`_
+library:
+
+.. code:: python
+
+    from huggingface_hub import hffs
+
+    # List crawl archives
+    for path in hffs.ls('hf://buckets/commoncrawl/commoncrawl/crawl-data/'):
+        print(path)
+
+    # List segments in a specific crawl
+    for path in hffs.ls('hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/'):
+        print(path)
+
+    # List WARC files in a segment
+    for path in hffs.ls('hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/segments/1775805908305.14/warc/'):
+        print(path)
+
+Note: When using ``hffs.ls()``, paths are returned without the ``hf://`` prefix.
+To open files returned by ``ls()``, prepend the protocol:
+
+.. code:: python
+
+    files = hffs.ls('hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/segments/1775805908305.14/warc/')
+    for file_path in files[:1]:  # files is like 'buckets/commoncrawl/.../file.warc.gz'
+        with fsspec_open('hf://' + file_path, 'rb') as fh:
+            for record in ArchiveIterator(fh):
+                ...
 
 
 Contributing

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,17 @@ setup(
         'all': [
             'brotlipy',
             'warcio[s3]',
+            'warcio[hf]',
         ],
         's3': [
             'fsspec',
             's3fs',
             'aiohttp',
             'requests',
-        ]
+        ],
+        'hf': [
+            'huggingface_hub',
+        ],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test/test_hf.py
+++ b/test/test_hf.py
@@ -1,0 +1,62 @@
+import pytest
+from warcio.archiveiterator import ArchiveIterator
+from warcio.cli import main
+from warcio.utils import fsspec_open
+
+
+try:
+    import fsspec  # noqa: F401
+    import huggingface_hub  # noqa: F401
+    HAS_FSSPEC = True
+except ModuleNotFoundError:
+    HAS_FSSPEC = False
+
+if not HAS_FSSPEC:
+    pytest.skip("fsspec[hf] is not installed", allow_module_level=True)
+
+
+def _assert_valid_warc(stream):
+    first_uri = None
+    for record in ArchiveIterator(stream):
+        if record.rec_type == 'response':
+            first_uri = record.rec_headers.get_header('WARC-Target-URI')
+            break
+    assert first_uri is not None
+    assert first_uri.startswith("http")
+
+
+def test_hf_from_file():
+    # Read WARC records directly from HF Buckets
+    with fsspec_open(
+        'hf://buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/'
+        'segments/1775805908305.14/warc/CC-MAIN-20260410081153-20260410111153-00000.warc.gz',
+        'rb'
+    ) as stream:
+        _assert_valid_warc(stream)
+
+
+def test_hf_from_directory():
+    # Iterate on WARC files
+    files = huggingface_hub.hffs.ls('buckets/commoncrawl/commoncrawl/crawl-data/CC-MAIN-2026-17/segments/1775805908305.14/warc/')
+    assert len(files) == 1000
+    assert files[0]['name'].endswith(".warc.gz")
+    for file in files[:1]:
+        with fsspec_open('hf://' + file['name'], 'rb') as stream:
+            _assert_valid_warc(stream)
+
+
+def test_cli_index(capsys):
+    files = ['hf://buckets/lhoestq/commoncrawl-samples/example.warc.gz']
+    args = ['index', '-f', 'offset,length,http:status,warc-type,filename']
+    args.extend(files)
+
+    expected = """\
+{"offset": "0", "length": "353", "warc-type": "warcinfo", "filename": "example.warc.gz"}
+{"offset": "353", "length": "431", "warc-type": "warcinfo", "filename": "example.warc.gz"}
+{"offset": "784", "length": "1228", "http:status": "200", "warc-type": "response", "filename": "example.warc.gz"}
+{"offset": "2012", "length": "609", "warc-type": "request", "filename": "example.warc.gz"}
+{"offset": "2621", "length": "586", "http:status": "200", "warc-type": "revisit", "filename": "example.warc.gz"}
+{"offset": "3207", "length": "609", "warc-type": "request", "filename": "example.warc.gz"}
+"""
+    res = main(args=args)
+    assert capsys.readouterr().out == expected


### PR DESCRIPTION
Hi @tw4l and team

Hugging Face buckets is now a great alternative to S3 to access Common Crawl, especially from other region and provider than AWS us-east-1.

I wanted to make the warcio community aware of this so I added some documentation around it in the README

Let me know if this is the right place and feel free to suggest edits.

Ultimately I'd like to democratize Common Crawl's usage given its impact in AI / LLM pretraining.
Right now its access is too restricted due to AWS contraints and the costs that come with it IMO.

cc @wumpus for viz as well