### PR TITLE
Don't crash loading http headers for a record with no target URI

### DIFF
--- a/test/test_archiveiterator.py
+++ b/test/test_archiveiterator.py
@@ -102,6 +102,18 @@ class TestArchiveIterator(object):
         assert a.reader == None
         assert a.read_to_end() == None
 
+    def test_load_http_headers_no_target_uri(self):
+        """ A record with no WARC-Target-URI (uri is None) used to raise
+        AttributeError from uri.startswith(); it should just skip parsing
+        http headers.
+        """
+        from warcio.recordloader import ArcWarcRecordLoader
+
+        loader = ArcWarcRecordLoader()
+        result = loader.load_http_headers(
+            'response', None, BytesIO(b'HTTP/1.1 200 OK\r\n\r\n'), 100)
+        assert result is None
+
     def test_unseekable(self):
         """ Test iterator on unseekable 3 record uncompressed WARC input
         """

--- a/warcio/recordloader.py
+++ b/warcio/recordloader.py
@@ -180,8 +180,9 @@ class ArcWarcRecordLoader(object):
         if rec_type not in self.HTTP_RECORDS:
             return None
 
-        # only http:/https: uris can have http headers
-        if not uri.startswith(self.HTTP_SCHEMES):
+        # only http:/https: uris can have http headers (a record with no
+        # WARC-Target-URI has uri=None, which can't have http headers either)
+        if not uri or not uri.startswith(self.HTTP_SCHEMES):
             return None
 
         # request record: parse request


### PR DESCRIPTION
Iterating a WARC whose record has no `WARC-Target-URI` header raises a bare `AttributeError`:

```
File "warcio/recordloader.py", line 184, in load_http_headers
    if not uri.startswith(self.HTTP_SCHEMES):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

`load_http_headers` checks the record's URI scheme with `uri.startswith(...)`, but a record missing `WARC-Target-URI` has `uri=None`. I guard for a missing uri and return `None` (such a record can't carry http headers), so a malformed archive is handled the same as a non-http record instead of raising. Valid records and normal http/https records are unaffected.

Added a test in test_archiveiterator.py; it raises AttributeError on `master` and passes with the change, and the archive-iterator suite still passes. Found it by fuzzing `ArchiveIterator` with mutated WARC files.